### PR TITLE
fixing the links in the readme file and adding github ssh key guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ SikhiToTheMax Desktop App
 [![Build Status](https://api.travis-ci.org/KhalisFoundation/sttm-desktop.svg?branch=release)](https://travis-ci.org/KhalisFoundation/sttm-desktop) [![Build Status](https://ci.appveyor.com/api/projects/status/github/khalisfoundation/sttm-desktop?branch=release&svg=true)](https://ci.appveyor.com/project/navdeepsinghkhalsa/sttm-desktop)
 
 ## Prerequisites
- 1. Node - [https://nodejs.org/en/download/]()
- 2. yarn - [https://yarnpkg.com/en/docs/install]()
+ 1. [Node](https://nodejs.org/en/download/)
+ 2. [yarn](https://yarnpkg.com/en/docs/install)
+ 3. [Github SSH Key Setup](https://help.github.com/articles/connecting-to-github-with-ssh/)
  
 ## Installation
  * Clone repository


### PR DESCRIPTION
Fixing the links in the readme file.

Also added the link to github ssh key guide for generating and linking ssh key to the github account.