### PR TITLE
Add empty slide button

### DIFF
--- a/app.js
+++ b/app.js
@@ -238,6 +238,17 @@ ipcMain.on('show-text', (event, arg) => {
   }
 });
 
+ipcMain.on('show-empty-slide', (event, arg) => {
+  if (viewerWindow) {
+    viewerWindow.webContents.send('show-empty-slide', arg);
+  } else {
+    createViewer({
+      send: 'show-empty-slide',
+      data: arg,
+    });
+   }
+ });
+
 ipcMain.on('update-settings', () => {
   if (viewerWindow) {
     viewerWindow.webContents.send('update-settings');

--- a/app.js
+++ b/app.js
@@ -246,8 +246,8 @@ ipcMain.on('show-empty-slide', (event, arg) => {
       send: 'show-empty-slide',
       data: arg,
     });
-   }
- });
+  }
+});
 
 ipcMain.on('update-settings', () => {
   if (viewerWindow) {

--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -340,6 +340,11 @@ module.exports = {
     global.platform.ipc.send('show-text', { text });
   },
 
+  sendEmptySlide() {
+    viewer.showEmptySlide();
+    global.platform.ipc.send('show-empty-slide');
+  },
+
   'presenter-view': function presenterView() {
     updateViewerScale();
   },

--- a/www/js/viewer.js
+++ b/www/js/viewer.js
@@ -103,7 +103,7 @@ module.exports = {
     $message.appendChild(h('div.slide.active', h('h1.gurmukhi.gurbani', text)));
   },
 
-showEmptySlide() {
+  showEmptySlide() {
     hideDecks();
     document.getElementById('empty-slide-button').classList.add('empty-on');
   },

--- a/www/js/viewer.js
+++ b/www/js/viewer.js
@@ -34,6 +34,10 @@ global.platform.ipc.on('show-text', (event, data) => {
   module.exports.showText(data.text);
 });
 
+global.platform.ipc.on('show-empty-slide', () => {
+  module.exports.showEmptySlide();
+});
+
 global.platform.ipc.on('update-settings', () => {
   prefs = JSON.parse(window.localStorage.getItem('prefs'));
   core.menu.settings.applySettings(prefs);
@@ -97,5 +101,10 @@ module.exports = {
       $message.removeChild($message.firstChild);
     }
     $message.appendChild(h('div.slide.active', h('h1.gurmukhi.gurbani', text)));
+  },
+
+showEmptySlide() {
+    hideDecks();
+    document.getElementById('empty-slide-button').classList.add('empty-on');
   },
 };


### PR DESCRIPTION
This PR adds an empty slide  button on right bottom of the navigator. (#56 )
![output_yghwjk](https://user-images.githubusercontent.com/1131610/35819824-d04a0a40-0ac9-11e8-9c9b-3d21c63a2130.gif)
Behavior is simple, you click on the icon and it hides the decks and you see an empty space on the viewer. Once you click on any panktee, the empty space is again replaced with the panktee that you clicked. While there's an empty space on viewer, the `emptySlideButton` stays hidden, and it pops right back when you click on a panktee. 

I first tried adding an actual div called empty slide, but then found it unnecessary and just went with hideDecks function. I have tried to mimic the workflow that was being used on `showText` and `showLine` functions. 

I am sending separate PR to sttm-core as well that goes hand-in-hand with this PR.
https://github.com/KhalisFoundation/sttm-core/pull/2