### PR TITLE
Adding help section

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,53 @@
+###  Video Tutorial
+
+<div class="videoWrapper"><iframe width="100%" height="400px" src="https://www.youtube.com/embed/ZDX8nPkDBSc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen=""></iframe></div>
+
+### How do I install the desktop application?
+
+You can install SikhiToTheMax (STTM) by visiting [this website](https://khalisfoundation.org/portfolio/sikhitothemax-everywhere/) and choosing the Windows or macOS download link. After that, open the installer and follow the steps that are displayed. ![](https://www.sikhitothemax.org/assets/images/help/desktop-search-ex.png)
+
+### How do I search for a shabad?
+
+After launching STTM, by default you can search for a shabad by entering the first letter of each word. For example, if the shabad is ਗੁਰੁ ਮੇਰੈ ਸੰਗਿ ਸਦਾ ਹੈ ਨਾਲੇ , you would enter "gmsshn".'" ![](https://www.sikhitothemax.org/assets/images/help/desktop-search-ex.png) Alternatively, you can click on the gurmukhi keyboard icon and type in the letters manually. ![](https://www.sikhitothemax.org/assets/images/help/desktop-keyboard.png)
+
+### What do the different search types do?
+
+*   First Letter (Start)
+    *   The letters you input must be from the START of a line in a shabad.
+*   First Letter (Anywhere)
+    *   The letters you input can be from any part of the line. For example, you can start your search by typing in the first letter of every word in the second half of a shabad’s line.
+*   Full Word (Gurmukhi)
+    *   You can type in the full word(s) in gurmukhi that you are searching for.
+*   English Translation (Full Word)
+    *   You can search for shabads via the english translations. For example, type in the word "bird" and the results will show all shabads that include a translation for "bird".
+
+### I can't find my shabad.
+
+*   STTM's database includes shabads from Sri Guru Granth Sahib Ji, Sri Dasam Granth Sahib, Bhai Gurdas Jee, Bhai Gurdas Singh Jee, Bhai Nand Lal Jee, and various rehatnamas and thankhanamas. If your shabad is not from one of those sources, it will not appear.
+*   If you verified your shabad should be in the database and it is still not coming up, make sure you are typing in the correct letters for search. If you aren’t sure about a letter, or are still having difficulties, try using one of the different search types to locate the shabad.
+
+
+### How do I connect STTM to a projector?
+
+Plug in your computer to the projector or TV. Once you do this, go to your computer's display settings and change it to "Extended Desktop" (NOT mirroring). After that, launch STTM and turn on "Presenter View" in the settings! ![](https://www.sikhitothemax.org/assets/images/help/desktop-extend-pc.png) ![](https://www.sikhitothemax.org/assets/images/help/desktop-extend-mac.png)
+
+### How do I change the background color?
+
+After launching STTM, click the icon for settings, and choose your theme. ![](https://www.sikhitothemax.org/assets/images/help/desktop-theme.png)
+
+### Can you view the Gurbani in Larivaar?
+
+Yes! After launching STTM, click the icon for settings, and choose the Larivaar option. ![](https://www.sikhitothemax.org/assets/images/help/desktop-larivaar.png)</div>
+
+
+### How can I make the fonts on the screen smaller?
+
+<div>After launching STTM, click the icon for settings, and scroll down for options to adjust the font size. ![](https://www.sikhitothemax.org/assets/images/help/desktop-font-size.png)</div>
+
+### Where can I see my previous shabads?
+
+When using STTM in “Presenter View”, your history will appear in the bottom right quadrant. You can click any of the shabads in the list to bring them back up as your primary one. ![](https://www.sikhitothemax.org/assets/images/help/desktop-history.png)
+
+### How do I report a mistake?
+
+Visit [SikhiToTheMax.org](https://sikhitothemax.org) and click "[Feedback](https://goo.gl/plk23h)" at the bottom of the page.

--- a/HELP.md
+++ b/HELP.md
@@ -1,6 +1,6 @@
 ###  Video Tutorial
 
-<div class="videoWrapper"><iframe width="100%" height="400px" src="https://www.youtube.com/embed/ZDX8nPkDBSc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen=""></iframe></div>
+<div class="video-wrapper"><iframe width="100%" height="400px" src="https://www.youtube.com/embed/ZDX8nPkDBSc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen=""></iframe></div>
 
 ### How do I install the desktop application?
 

--- a/app.js
+++ b/app.js
@@ -13,25 +13,37 @@ const appVersion = app.getVersion();
 
 let mainWindow;
 let viewerWindow = false;
-let changelogWindow = false;
+const secondaryWindows = {
+  changelogWindow: {
+    obj: false,
+    url: `file://${__dirname}/www/changelog.html`,
+    onClose: () => { store.set('changelog-seen', appVersion); },
+  },
+  helpWindow: {
+    obj: false,
+    url: `file://${__dirname}/www/help.html`,
+  },
+};
 let manualUpdate = false;
 const viewerWindowPos = {};
 
-function openChangelog() {
-  changelogWindow = new BrowserWindow({
+function openSecondaryWindow(windowName) {
+  const window = secondaryWindows[windowName];
+  window.obj = new BrowserWindow({
     width: 725,
     height: 800,
     show: false,
   });
-  changelogWindow.webContents.on('did-finish-load', () => {
-    changelogWindow.show();
+  window.obj.webContents.on('did-finish-load', () => {
+    window.obj.show();
   });
-  changelogWindow.loadURL(`file://${__dirname}/www/changelog.html`);
+  window.obj.loadURL(window.url);
 
-  // Update changelog last seen pref when seen
-  changelogWindow.on('close', () => {
-    store.set('changelog-seen', appVersion);
-    changelogWindow = false;
+  window.obj.on('close', () => {
+    window.obj = false;
+    if (window.onClose) {
+      window.onClose();
+    }
   });
 }
 
@@ -184,7 +196,7 @@ app.on('ready', () => {
     // Show changelog if last version wasn't seen
     const lastSeen = store.get('changelog-seen');
     if (lastSeen !== appVersion) {
-      openChangelog();
+      openSecondaryWindow('changelogWindow');
     }
     if (!viewerWindow) {
       createViewer();
@@ -197,6 +209,7 @@ app.on('ready', () => {
     if (viewerWindow && !viewerWindow.isDestroyed()) {
       viewerWindow.close();
     }
+    const changelogWindow = secondaryWindows.changelogWindow.obj;
     if (changelogWindow && !changelogWindow.isDestroyed()) {
       changelogWindow.close();
     }
@@ -261,7 +274,7 @@ ipcMain.on('update-settings', () => {
   }
 });
 
-exports.openChangelog = openChangelog;
+exports.openSecondaryWindow = openSecondaryWindow;
 exports.appVersion = appVersion;
 exports.checkForUpdates = checkForUpdates;
 exports.autoUpdater = autoUpdater;

--- a/www/help.html
+++ b/www/help.html
@@ -6,9 +6,9 @@
   <link rel="stylesheet" href="assets/css/bundle.css">
 </head>
 <body class="noselect">
-  <div id="changelog-frame" class="markdown-frame">
-    <h1>Changelog</h1>
-    <div id="changelog"></div>
+  <div id="help-frame" class="markdown-frame">
+    <h1>Help</h1>
+    <div id="help"></div>
   </div>
   <script src="js/markdownToHTML.js"></script>
 </body>

--- a/www/help.html
+++ b/www/help.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Changelog</title>
+  <title>SikhiToTheMax Help</title>
   <link rel="stylesheet" href="assets/css/bundle.css">
 </head>
 <body class="noselect">

--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -169,9 +169,15 @@ const winMenu = [
       },
       ...updateMenu,
       {
+        label: 'Guide...',
+        click: () => {
+          main.openSecondaryWindow('helpWindow');
+        },
+      },
+      {
         label: 'Changelog...',
         click: () => {
-          main.openChangelog();
+          main.openSecondaryWindow('changelogWindow');
         },
       },
     ],
@@ -189,9 +195,15 @@ const macMenu = [
       },
       ...updateMenu,
       {
+        label: 'Guide...',
+        click: () => {
+          main.openSecondaryWindow('helpWindow');
+        },
+      },
+      {
         label: 'Changelog...',
         click: () => {
-          main.openChangelog();
+          main.openSecondaryWindow('changelogWindow');
         },
       },
       {

--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -193,19 +193,6 @@ const macMenu = [
         label: 'About SikhiToTheMax',
         role: 'about',
       },
-      ...updateMenu,
-      {
-        label: 'Guide...',
-        click: () => {
-          main.openSecondaryWindow('helpWindow');
-        },
-      },
-      {
-        label: 'Changelog...',
-        click: () => {
-          main.openSecondaryWindow('changelogWindow');
-        },
-      },
       {
         type: 'separator',
       },
@@ -250,6 +237,28 @@ const macMenu = [
     ],
   },
   ...menuTemplate,
+  {
+    label: 'Help',
+    submenu: [
+      {
+        label: '',
+        enabled: false,
+      },
+      ...updateMenu,
+      {
+        label: 'Guide...',
+        click: () => {
+          main.openSecondaryWindow('helpWindow');
+        },
+      },
+      {
+        label: 'Changelog...',
+        click: () => {
+          main.openSecondaryWindow('changelogWindow');
+        },
+      },
+    ],
+  },
   ...devMenu,
 ];
 const menu = Menu.buildFromTemplate(process.platform === 'darwin' || process.platform === 'linux' ? macMenu : winMenu);

--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -193,6 +193,7 @@ const macMenu = [
         label: 'About SikhiToTheMax',
         role: 'about',
       },
+      ...updateMenu,
       {
         type: 'separator',
       },
@@ -240,11 +241,6 @@ const macMenu = [
   {
     label: 'Help',
     submenu: [
-      {
-        label: '',
-        enabled: false,
-      },
-      ...updateMenu,
       {
         label: 'Guide...',
         click: () => {

--- a/www/js/markdownToHtml.js
+++ b/www/js/markdownToHtml.js
@@ -1,0 +1,16 @@
+const marked = require('marked');
+const fs = require('fs');
+const path = require('path');
+
+const markdownFiles = {
+  changelog: '../CHANGELOG.md',
+  help: '../HELP.md',
+};
+
+function markdownToHTML(file) {
+  const fileMD = fs.readFileSync(path.resolve(__dirname, markdownFiles[file]), 'utf8');
+  const $file = document.getElementById(file);
+  if ($file) { $file.innerHTML = marked(fileMD); }
+}
+
+Object.keys(markdownFiles).forEach(markdownToHTML);

--- a/www/src/scss/_changelog.scss
+++ b/www/src/scss/_changelog.scss
@@ -1,7 +1,0 @@
-#changelog-frame {
-  padding: 35px 25px;
-
-  h1 {
-    margin: 0;
-  }
-}

--- a/www/src/scss/_display-next-line.scss
+++ b/www/src/scss/_display-next-line.scss
@@ -19,7 +19,7 @@
   }
 
   .slide.active {
-    display: inline-block;
+    display: block;
 
     & + .slide {
       display: inline-block;

--- a/www/src/scss/_markdown.scss
+++ b/www/src/scss/_markdown.scss
@@ -1,0 +1,65 @@
+$container: 700px;
+$base-font-size: 16px;
+$ratio:1.5;
+$vertical-rhythm: $base-font-size * $ratio;
+
+.markdown-frame {
+  color: #555;
+  font-size: $base-font-size;
+  line-height: $ratio;
+  margin: auto;
+  max-width: $container;
+  padding: $vertical-rhythm;
+
+  h2,
+  h3,
+  h4 {
+    color: #333;
+    line-height: 1;
+    margin-bottom: $vertical-rhythm/2;
+    margin-top: $vertical-rhythm;
+  }
+
+  h1 {
+    color: #111;
+    font-size: $vertical-rhythm * 2;
+    line-height: 1;
+    margin-bottom: $vertical-rhythm * 2;
+    text-align: center;
+  }
+
+  h2 {
+    font-size: $vertical-rhythm;
+  }
+
+  h3 {
+    font-size: $vertical-rhythm;
+    font-weight: normal;
+  }
+
+  h4 {
+    font-size: $base-font-size;
+    line-height: $ratio;
+  }
+
+  p {
+    margin-top: 0;
+  }
+
+  ul {
+    margin-left: $vertical-rhythm;
+  }
+
+  img {
+    border-radius: $vertical-rhythm/2;
+    display: block;
+    margin: auto;
+    margin-bottom: $vertical-rhythm;
+    margin-top: $vertical-rhythm/2;
+    max-width: 100%;
+  }
+
+  iframe {
+    border-radius: $vertical-rhythm/2;
+  }
+}

--- a/www/src/scss/styles.scss
+++ b/www/src/scss/styles.scss
@@ -15,7 +15,7 @@ $title-bar-offset: 25px;
 
 @import
   "../../core/scss/styles.scss",
-  "changelog",
+  "markdown",
   "theme-dark",
   "theme-light",
   "update",


### PR DESCRIPTION
In order to solve issue #38  I ended up doing couple of stuff that I believe will help us in adding future markdown based  static content windows.

* I refactored `openChangeLogWindow` function into `openSecondaryWindow` so that it can open any window we want it to by just passing an argument.
* Then used `openSecondaryWindow` to open a help/guide window.
* Refactored `changelog.js`  into `markdownToHTML` so that it can convert any markdown file into html and load into respective id.
* Refactored `changlog.scss` into `markdown.scss` to allow it to style all the markdown based files
* Added content into newly created `HELP.md`
* Added some typographic rules and vertical rhythm into `markdown.scss`. Now both changelog window and help window look beautiful <3 <3 
For now I am loading images and videos from website to not bloat the app size, however let me know if we want to load them into app.