### PR TITLE
Auto Save Overlay settings. Sync colours for overlay settings

### DIFF
--- a/www/js/defaults.json
+++ b/www/js/defaults.json
@@ -44,7 +44,7 @@
     "overlayPrefs": {
       "overlayVars": {
         "layout": "split",
-        "bgColor": "#800080",
+        "bgColor": "#2c3e50",
         "textColor": "#EAC445"
       },
       "gurbani": {


### PR DESCRIPTION
On any change of an Overlay setting (position, bg colour, font colour) from the customizer, save that setting and it will show on next `line-show` event. 

default background to match obs.html default.