### PR TITLE
adds notification with file path for live feed

### DIFF
--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -1,5 +1,6 @@
 /* global Mousetrap */
 const electron = require('electron');
+const Noty = require('noty');
 
 const remote = electron.remote;
 const app = remote.app;
@@ -476,6 +477,19 @@ module.exports = {
 
   'presenter-view': function presenterView() {
     updateViewerScale();
+  },
+
+  livefeed() {
+    if (document.body.classList.contains('livefeed')) {
+      const userDataPath = app.getPath('userData');
+      new Noty({
+        type: 'info',
+        text: `<h3> Live Feed is on now. </h3> You can find files <code> sttm-Gurbani.txt </code> and <code> sttm-English.txt </code> in <code> ${userDataPath} </code> `,
+        closeWith: ['click', 'button'],
+        timeout: 7000,
+        layout: 'topRight',
+      }).show();
+    }
   },
 
   autoplay() {


### PR DESCRIPTION
<img width="415" alt="screen shot 2018-07-08 at 6 16 53 pm" src="https://user-images.githubusercontent.com/1131610/42419903-1ed233ca-82db-11e8-8d58-009b929f5824.png">

We  already had `noty` library ready to take on notifications. So I used that library to show the information about live feed. It has timeout of 7seconds and can be closed anytime with close button. Currently it shows on top-right, but it can also be shown in bottom-right (close to where we shift live feed option). The reason I kept it top-right is because 
a) that's default for most of apps, so user expects to look at top right for notifications 
b) it doesn't obstruct user's workflow in navigator (for those who already know where the files are).

🙏 