### PR TITLE
[231] Allow Scripture filtering and quick switch between search types

### DIFF
--- a/www/js/search-database.js
+++ b/www/js/search-database.js
@@ -76,13 +76,10 @@ module.exports = {
         condition = `${searchCol} = ${dbQuery}`;
 
         switch (global.core.search.currentMeta.source) {
-          case CONSTS.SOURCE_TYPES.DASAM_GRANTH:
-          case CONSTS.SOURCE_TYPES.GURDAS_VAARAN:
-          case CONSTS.SOURCE_TYPES.GURU_GRANTH_SAHIB:
-          case CONSTS.SOURCE_TYPES.GURDAS_JI_VAARAN:
-            angSearchSourceId = global.core.search.currentMeta.source;
+          case null:
             break;
           default:
+            angSearchSourceId = global.core.search.currentMeta.source;
             break;
         }
         condition = `${searchCol} = ${dbQuery} AND v.SourceID = '${angSearchSourceId}'`;

--- a/www/js/search-database.js
+++ b/www/js/search-database.js
@@ -79,7 +79,7 @@ module.exports = {
           case CONSTS.SOURCE_TYPES.DASAM_GRANTH:
           case CONSTS.SOURCE_TYPES.GURDAS_VAARAN:
           case CONSTS.SOURCE_TYPES.GURU_GRANTH_SAHIB:
-          case CONSTS.SOURCE_TYPES.NAND_LAL_VAARAN:
+          case CONSTS.SOURCE_TYPES.GURDAS_JI_VAARAN:
             angSearchSourceId = global.core.search.currentMeta.source;
             break;
           default:

--- a/www/js/search-database.js
+++ b/www/js/search-database.js
@@ -10,6 +10,8 @@ module.exports = {
     let dbQuery = '';
     let searchCol = '';
     let condition = '';
+    // default source for ang search to GURU_GRANTH_SAHIB
+    let angSearchSourceId = CONSTS.SOURCE_TYPES.GURU_GRANTH_SAHIB;
     const order = [];
     const limit = ' 0,20';
     switch (searchType) {
@@ -71,7 +73,19 @@ module.exports = {
       case CONSTS.SEARCH_TYPES.ANG: // Ang
         searchCol = 'PageNo';
         dbQuery = parseInt(searchQuery, 10);
-        condition = `${searchCol} = ${dbQuery} AND v.SourceID = '${global.core.search.currentMeta.source || 'G'}'`;
+        condition = `${searchCol} = ${dbQuery}`;
+
+        switch (global.core.search.currentMeta.source) {
+          case CONSTS.SOURCE_TYPES.DASAM_GRANTH:
+          case CONSTS.SOURCE_TYPES.GURDAS_VAARAN:
+          case CONSTS.SOURCE_TYPES.GURU_GRANTH_SAHIB:
+          case CONSTS.SOURCE_TYPES.NAND_LAL_VAARAN:
+            angSearchSourceId = global.core.search.currentMeta.source;
+            break;
+          default:
+            break;
+        }
+        condition = `${searchCol} = ${dbQuery} AND v.SourceID = '${angSearchSourceId}'`;
         break;
       default:
         break;

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -342,7 +342,10 @@ module.exports = {
     ) {
       // don't search if there is less than a 100ms gap in between key presses
       clearTimeout(newSearchTimeout);
-      newSearchTimeout = setTimeout(() => this.search(e), 100);
+      newSearchTimeout = setTimeout(() => {
+        this.searchType = store.get('searchOptions.searchType');
+        this.search(e);
+      }, 100);
       this.$angSearch.value = '';
     }
   },
@@ -381,14 +384,16 @@ module.exports = {
   },
 
   searchByAng() {
-    this.search(4);
+    this.searchType = 4;
+    this.search();
     this.$search.value = '';
   },
 
   changeSearchSource(value) {
     this.searchSource = value;
-    this.search();
+    currentMeta.source = value === 'all' ? null : value;
     store.set('searchOptions.searchSource', this.searchSource);
+    this.search();
   },
 
   changeSearchLanguage(value) {
@@ -458,12 +463,11 @@ module.exports = {
     }
   },
 
-  search(e) {
-    let searchType = this.searchType;
+  search() {
+    const searchType = this.searchType;
     let searchQuery;
-    if (e === 4) {
+    if (searchType === 4) {
       searchQuery = this.$angSearch.value;
-      searchType = e;
     } else {
       searchQuery = this.$search.value;
     }
@@ -471,7 +475,6 @@ module.exports = {
       global.platform.search.search(searchQuery, searchType, this.searchSource);
     } else {
       this.$results.innerHTML = '';
-      document.getElementById('search-options').style.display = 'none';
     }
   },
 
@@ -511,7 +514,6 @@ module.exports = {
     } else {
       this.$results.innerHTML = '';
       this.$results.appendChild(h('li.roman', h('span', 'No results')));
-      document.getElementById('search-options').style.display = 'none';
     }
   },
 

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -482,6 +482,7 @@ module.exports = {
 
   printResults(rows) {
     if (rows.length > 0) {
+      document.getElementById('search-options').style.display = 'block';
       this.$results.innerHTML = '';
       rows.forEach(item => {
         const resultNode = [];
@@ -514,6 +515,9 @@ module.exports = {
     } else {
       this.$results.innerHTML = '';
       this.$results.appendChild(h('li.roman', h('span', 'No results')));
+      if (this.searchSource === CONSTS.SOURCE_TYPES.ALL_SOURCES) {
+        document.getElementById('search-options').style.display = 'none';
+      }
     }
   },
 

--- a/www/src/scss/_search.scss
+++ b/www/src/scss/_search.scss
@@ -124,7 +124,6 @@
 }
 
 #search-options {
-  display: none;
   height: 36px;
   overflow: hidden;
   padding-right: 12px;


### PR DESCRIPTION
![sf](https://user-images.githubusercontent.com/2982784/43937054-610f4248-9c10-11e8-8c8d-2bfc807c65a2.gif)

Changing the behavior to always show the scripture filter. 
For Ang Search, default to G for source ID when ~~not one of ```DASAM_GRANTH, GURDAS_VAARAN, GURU_GRANTH_SAHIB, NAND_LAL_VAARAN:```~~ All Sources
When going back to normal search, use the same scripture source and clear ang search. 
