### PR TITLE
Show which scripture is selected

### DIFF
--- a/www/js/search.js
+++ b/www/js/search.js
@@ -197,13 +197,14 @@ const searchOptions = h(
     {
       onchange() {
         module.exports.changeSearchSource(this.value);
+        document.getElementById('source-selection').innerText = CONSTS.SOURCE_TEXTS[this.value];
       },
     },
     sourceOptions,
   ),
   h(
-    'label.filter-text', { htmlFor: 'search-source' },
-    'Scripture'),
+    'label.filter-text#source-selection', { htmlFor: 'search-source' },
+    CONSTS.SOURCE_TEXTS[store.get('searchOptions.searchSource')]),
 );
 
 const navPageLinks = [];

--- a/www/src/scss/_search.scss
+++ b/www/src/scss/_search.scss
@@ -127,7 +127,7 @@
   height: 36px;
   overflow: hidden;
   padding-right: 12px;
-  text-align: right;
+  text-align: left;
   transition: height 250ms linear;
 
   .filter-text {


### PR DESCRIPTION
Moving scripture filter to left as well so when selection changes the difference in width does not move the filter around too much. 
![scripture](https://user-images.githubusercontent.com/2982784/44245164-3e72bb80-a18c-11e8-914b-6f082d2d3f6d.gif)
