### PR TITLE
4.2.3 (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## SikhiToTheMax Desktop App
 
+### 4.2.3 - _181115_
+* Bug Fixes 
+
 ### 4.2.1 - _181103_
 #### Improved
 * Bug Fixes for Windows 7 and 8 users. For the best Sikhi to the Max experience, consider updating to Windows 10. 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "productName": "SikhiToTheMax",
   "name": "sttm-desktop",
-  "version": "4.2.1",
+  "version": "4.2.3",
   "description": "The SikhiToTheMax desktop app",
   "main": "app.js",
   "scripts": {

--- a/www/js/banidb/sqlite-search.js
+++ b/www/js/banidb/sqlite-search.js
@@ -129,8 +129,10 @@ const query = (searchQuery, searchType, searchSource) => (
         reject(err);
       } else {
         rows.map((row) => {
-          // eslint-disable-next-line no-param-reassign
+          /* eslint-disable no-param-reassign */
           row.Shabads = [{ ShabadID: row.ShabadID }];
+          row.Source = { SourceID: row.SourceID };
+          /* eslint-enable */
           return row;
         });
         resolve(rows);

--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -461,9 +461,9 @@ module.exports = {
     global.platform.ipc.send('clear-apv');
   },
 
-  sendLine(shabadID, lineID, Line) {
-    global.webview.send('show-line', { shabadID, lineID });
-    const showLinePayload = { shabadID, lineID, Line, live: false, larivaar: store.get('userPrefs.slide-layout.display-options.larivaar') };
+  sendLine(shabadID, lineID, Line, rows) {
+    global.webview.send('show-line', { shabadID, lineID, rows });
+    const showLinePayload = { shabadID, lineID, Line, live: false, larivaar: store.get('userPrefs.slide-layout.display-options.larivaar'), rows };
     if (document.body.classList.contains('livefeed')) {
       showLinePayload.live = true;
     }

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -53,20 +53,22 @@ function spaceBar(e) {
   e.preventDefault();
 }
 
-function prevLine() {
+function prevLine(e) {
   // Find position of current line in Shabad
   const pos = search.currentShabad.indexOf(search.currentLine);
   if (pos > 0) {
     highlightLine(search.currentShabad[pos - 1]);
   }
+  e.preventDefault();
 }
 
-function nextLine() {
+function nextLine(e) {
   // Find position of current line in Shabad
   const pos = search.currentShabad.indexOf(search.currentLine);
   if (pos < search.currentShabad.length - 1) {
     highlightLine(search.currentShabad[pos + 1]);
   }
+  e.preventDefault();
 }
 
 // Keyboard shortcuts

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -24,6 +24,8 @@ const kbPages = [];
 let currentMeta = {};
 let newSearchTimeout;
 let autoplaytimer;
+// Temp
+const infiniteScroll = false;
 
 // build the search bar and toggles and append to HTML
 const searchInputs = h('div#search-container', [
@@ -251,8 +253,9 @@ document.body.addEventListener('click', e => {
 });
 
 function akhandPaatt() {
-  module.exports.$shabad.innerHTML = '';
-  global.controller.clearAPV();
+  // FIXME
+  // module.exports.$shabad.innerHTML = '';
+  // global.controller.clearAPV();
 }
 
 module.exports = {
@@ -553,8 +556,6 @@ module.exports = {
     }
     // add the line to the top of the session block
     this.$session.insertBefore(sessionItem, this.$session.firstChild);
-    // send the line to app.js, which will send it to the viewer window
-    global.controller.sendLine(ShabadID, LineID, Line);
     // are we in APV
     const apv = document.body.classList.contains('akhandpaatt');
     // load the Shabad into the controller
@@ -574,7 +575,7 @@ module.exports = {
     const $shabadList = this.$shabad || document.getElementById('shabad');
     $shabadList.innerHTML = '';
     currentShabad.splice(0, currentShabad.length);
-    if (apv) {
+    if (apv && infiniteScroll) {
       banidb.getAng(ShabadID)
         .then(ang => {
           currentMeta = ang;
@@ -640,7 +641,7 @@ module.exports = {
           {
             'data-line-id': item.ID,
             onclick: e => this.clickShabad(e, item.ShabadID || shabadID,
-                           item.ID, item),
+                           item.ID, item, rows),
           },
           [
             h('i.fa.fa-fw.fa-check'),
@@ -659,11 +660,14 @@ module.exports = {
       }
     });
     // scroll the Shabad controller to the current Panktee
-    const curPankteeTop = shabad.querySelector('.current').parentNode
-      .offsetTop;
-    this.$shabadContainer.scrollTop = curPankteeTop;
+    const $curPanktee = shabad.querySelector('.current');
+    if ($curPanktee) {
+      const curPankteeTop = $curPanktee.parentNode
+        .offsetTop;
+      this.$shabadContainer.scrollTop = curPankteeTop;
+    }
     // send the line to app.js, which will send it to the viewer window as well as obs file
-    global.controller.sendLine(shabadID, lineID, mainLine);
+    global.controller.sendLine(shabadID, lineID, mainLine, rows);
     // Hide next and previous links before loading first and last shabad
     const $shabadNext = document.querySelector('#shabad-next');
     const $shabadPrev = document.querySelector('#shabad-prev');
@@ -716,7 +720,7 @@ module.exports = {
     }
   },
 
-  clickShabad(e, ShabadID, LineID, Line) {
+  clickShabad(e, ShabadID, LineID, Line, rows) {
     /*
     if (window.socket !== undefined) {
       window.socket.emit('data', { shabadid: ShabadID, highlight: LineID });
@@ -732,7 +736,7 @@ module.exports = {
       // Change line to click target
       const $panktee = e.target;
       this.currentLine = LineID;
-      global.controller.sendLine(ShabadID, LineID, Line);
+      global.controller.sendLine(ShabadID, LineID, Line, rows);
       // Remove 'current' class from all Panktees
       Array.from(lines).forEach(el => el.classList.remove('current'));
       // Add 'current' and 'seen-check' to selected Panktee

--- a/www/src/scss/_search.scss
+++ b/www/src/scss/_search.scss
@@ -115,7 +115,7 @@
   }
 
   #search-page .block-list {
-    height: calc(100% - 116px - 128px);
+    height: calc(100% - 158px - 128px);
   }
 }
 
@@ -190,7 +190,7 @@ button {
   }
 
   .block-list {
-    height: calc(100% - 116px);
+    height: calc(100% - 158px);
     transition: height $transition-time $transition-easing;
     z-index: 5;
   }


### PR DESCRIPTION
* Roll Back to 4.1.0 (#363)

* Fix 356 detach viewer from db (#364)

* Revert "Roll Back to 4.1.0 (#363)"

This reverts commit 2092372f7ef2753b5e1ba7d711ae1146b9a9a770.

* Send rows to viewer
Remove BaniDB search from viewer
Separate infiniteScroll from APV
De-promisify synchronous createCards method

* Update SQLite payload to match Realm

* Prevent default action on arrow keys when using keyboard shortcuts

* Fix results block height so last result isn't hidden

* Update Changelog for Release (#365)