### PR TITLE
 adds asterisk as wild  char for realm search

### DIFF
--- a/www/js/banidb/realm-search.js
+++ b/www/js/banidb/realm-search.js
@@ -29,19 +29,29 @@ const query = (searchQuery, searchType, searchSource) => (
       case CONSTS.SEARCH_TYPES.FIRST_LETTERS: // First letter start
       case CONSTS.SEARCH_TYPES.FIRST_LETTERS_ANYWHERE: { // First letter anywhere
         searchCol = 'FirstLetterStr';
-        const operator = searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS ? 'BEGINSWITH' : 'CONTAINS';
+        let operator = searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS ? 'BEGINSWITH' : 'CONTAINS';
+        let isWildChar = false;
         for (let x = 0, len = saniQuery.length; x < len; x += 1) {
           let charCode = saniQuery.charCodeAt(x);
           if (charCode < 100) {
             charCode = `0${charCode}`;
           }
-          dbQuery += `,${charCode}`;
+          if (charCode === '042') {
+            isWildChar = true;
+            dbQuery += ',???';
+            operator = 'LIKE';
+          } else {
+            dbQuery += `,${charCode}`;
+          }
         }
 
         // Replace kh with kh pair bindi
         let replaced = '';
         if (dbQuery.includes('075')) {
           replaced = `OR ${searchCol} ${operator} '${dbQuery.replace(/075/g, '094')}'`;
+        }
+        if (isWildChar) {
+          dbQuery = searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS ? `${dbQuery}*` : `*${dbQuery}*`;
         }
         condition = `${searchCol} ${operator} '${dbQuery}' ${replaced}`;
         if (saniQuery.length < 3) {

--- a/www/js/banidb/realm-search.js
+++ b/www/js/banidb/realm-search.js
@@ -38,7 +38,7 @@ const query = (searchQuery, searchType, searchSource) => (
           }
           if (charCode === '042') {
             isWildChar = true;
-            dbQuery += ',???';
+            dbQuery += ',*';
             operator = 'LIKE';
           } else {
             dbQuery += `,${charCode}`;

--- a/www/js/banidb/sqlite-search.js
+++ b/www/js/banidb/sqlite-search.js
@@ -43,6 +43,8 @@ const query = (searchQuery, searchType, searchSource) => (
     let dbQuery = '';
     let searchCol = '';
     let condition = '';
+    let isWildChar = false;
+
     // Sanitize query
     const saniQuery = searchQuery.trim().replace("'", "\\'");
     // default source for ang search to GURU_GRANTH_SAHIB
@@ -58,7 +60,12 @@ const query = (searchQuery, searchType, searchSource) => (
           if (charCode < 100) {
             charCode = `0${charCode}`;
           }
-          dbQuery += `,${charCode}`;
+          if (charCode === '042') {
+            isWildChar = true;
+            dbQuery += ',___';
+          } else {
+            dbQuery += `,${charCode}`;
+          }
         }
 
         // Replace kh with kh pair bindi
@@ -68,7 +75,7 @@ const query = (searchQuery, searchType, searchSource) => (
         }
 
         // Use LIKE if anywhere, otherwise use operators
-        if (searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS_ANYWHERE) {
+        if ((searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS_ANYWHERE) || isWildChar) {
           condition = `${searchCol} LIKE '%${dbQuery}%'`;
           if (replaced) {
             condition += ` OR ${searchCol} LIKE '%${replaced}%'`;


### PR DESCRIPTION
<img width="693" alt="screenshot 2018-11-25 at 5 38 03 pm" src="https://user-images.githubusercontent.com/1131610/48978904-24287200-f0d9-11e8-8dec-9d6915f1da99.png">
<img width="689" alt="screenshot 2018-11-25 at 5 39 02 pm" src="https://user-images.githubusercontent.com/1131610/48978906-25599f00-f0d9-11e8-8dcc-3131987f45ff.png">
<img width="687" alt="screenshot 2018-11-25 at 5 39 45 pm" src="https://user-images.githubusercontent.com/1131610/48978908-25599f00-f0d9-11e8-8d74-a4632611d5c5.png">

I am currently setting one `*` for one letter (one word). It felt more natural to me (keeping in mind our users), should we make one asterisk mean any number of characters? 

In that case `*jtmv` would mean any number of characters before `jtmv`. @ManjotS @saintsoldierx 