### PR TITLE
Announcement formatting

### DIFF
--- a/www/js/menu.js
+++ b/www/js/menu.js
@@ -251,28 +251,31 @@ const announcementSlideButton = h(
               name: 'announcement-language',
               type: 'checkbox',
               onclick: () => {
-                const $announcementText = document.querySelector('.announcement-text');
-                $announcementText.classList.toggle('gurmukhi');
                 const isGurmukhi = document.querySelector('#announcement-language').checked;
-                $announcementText.value = '';
-                $announcementText.placeholder = isGurmukhi ? 'GoSxw ie`Qy ilKo ...' : 'Add announcement text here ..';
+                const placeholderText = isGurmukhi ? 'GoSxw ie`Qy ilKo ...' : 'Add announcement text here ..';
+
+                const $announcementText = document.querySelector('.announcement-text');
+                $announcementText.classList.toggle('gurmukhi', isGurmukhi);
+                $announcementText.setAttribute('data-placeholder', placeholderText);
               },
               value: 'gurmukhi' }),
           h('label',
             {
               htmlFor: 'announcement-language' })])]),
   h(
-    'textarea.announcement-text',
+    'div.announcement-text',
     {
-      placeholder: 'Add announcement text here ..',
-    }),
+      contentEditable: true,
+      'data-placeholder': 'Add announcement text here ...',
+    },
+  ),
   h(
     'button.announcement-slide-btn.button',
     {
       onclick: () => {
         analytics.trackEvent('display', 'announcement-slide');
         const isGurmukhi = document.querySelector('#announcement-language').checked;
-        const announcementText = document.querySelector('.announcement-text').value;
+        const announcementText = document.querySelector('.announcement-text').innerHTML;
         global.controller.sendText(announcementText, isGurmukhi);
       } },
     'Add Announcement'));

--- a/www/js/viewer.js
+++ b/www/js/viewer.js
@@ -314,13 +314,21 @@ const showLine = (ShabadID, LineID, rows) => {
 
 const showText = (text, isGurmukhi = false) => {
   hideDecks();
+
   $message.classList.add('active');
   while ($message.firstChild) {
     $message.removeChild($message.firstChild);
   }
-  const textNode = isGurmukhi ? h('h1.gurmukhi.gurbani', text) : h('h1.gurbani', text);
-  $message.appendChild(h('div.slide.active', textNode));
-  castText(text, isGurmukhi);
+
+  const $textIs = document.createElement('div');
+  $textIs.classList.add('gurbani');
+  if (isGurmukhi) {
+    $textIs.classList.add('gurmukhi');
+  }
+  $textIs.innerHTML = text;
+
+  $message.appendChild(h('div.slide.active#announcement-slide', $textIs));
+  castText($textIs.innerText, isGurmukhi);
 };
 
 const toggleSideMenu = () => {

--- a/www/src/scss/controller.scss
+++ b/www/src/scss/controller.scss
@@ -105,10 +105,11 @@ ul {
   }
 
   .announcement-text {
+    border: 1px solid white;
     border-radius: 10px;
     display: inline-block;
     margin: 0 20px 10px;
-    min-height: 40px;
+    min-height: 100px;
     outline: none;
     padding: 10px;
   }

--- a/www/src/scss/viewer.scss
+++ b/www/src/scss/viewer.scss
@@ -36,6 +36,11 @@ body {
   background-size: cover;
 }
 
+[contenteditable=true]:empty::before {
+  content: attr(data-placeholder);
+  display: block;
+}
+
 #viewer {
   margin: 0;
   overflow: auto;
@@ -242,6 +247,13 @@ h2 {
     display: flex;
     height: 100%;
     justify-content: space-between;
+
+    &#announcement-slide {
+      align-items: center;
+      display: flex;
+      height: 100vh;
+      justify-content: center;
+    }
   }
 
   #viewer-logo {

--- a/www/src/scss/viewer.scss
+++ b/www/src/scss/viewer.scss
@@ -36,7 +36,7 @@ body {
   background-size: cover;
 }
 
-[contenteditable=true]:empty::before {
+[contenteditable=true]:empty:not(:focus)::before {
   content: attr(data-placeholder);
   display: block;
 }


### PR DESCRIPTION
<img width="682" alt="screenshot 2018-12-12 at 6 32 11 pm" src="https://user-images.githubusercontent.com/1131610/49871440-4aba0d00-fe3c-11e8-8697-64a5bff0686e.png">

This fixes #269 , adds formatting to the announcement. To have even more formatting we can have a WYSIWYG or markdown editor, but I think this is good enough to start with. We can track analytics on this and then see how much people use it and decide priority accordingly. Also, the announcement is vertically in the centre now. The centring does not work in chromecast but the formatting is still preserved. 
