### PR TITLE
Add tracking for app version

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,6 +1,9 @@
 const ua = require('universal-analytics'); // https://www.npmjs.com/package/universal-analytics
 const isOnline = require('is-online');
 
+const pjson = require('./package.json');
+
+const appVersion = pjson.version;
 const trackingId = 'UA-45513519-12';
 
 class Analytics {
@@ -39,6 +42,7 @@ class Analytics {
                 el: label,
                 ev: value,
                 ua: useragent,
+                cd1: appVersion,
               })
               .send();
           }


### PR DESCRIPTION
This sets up App version tracking. There's an open issue with using the google analytics built in app-version dimension (https://issuetracker.google.com/issues/35353026). The work around is making a Custom dimension and tracking it this way. 

https://www.npmjs.com/package/universal-analytics#setting-persistent-parameters

![image](https://user-images.githubusercontent.com/2982784/51127886-759cd580-17db-11e9-8af4-9c93fb8a2a94.png)
