### PR TITLE
fixes slider drag by shifting from oninput to onchange

### DIFF
--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -178,7 +178,7 @@ function createSettingsPage(userPrefs) {
               'data-value': userPrefs[catKey][settingKey][optionKey],
               max: option.max,
               min: option.min,
-              oninput: (e) => {
+              onchange: (e) => {
                 const newVal = e.target.value;
                 e.target.dataset.value = newVal;
                 store.setUserPref(`${catKey}.${settingKey}.${optionKey}`, newVal);


### PR DESCRIPTION
we were unable to drag sliders because of `oninput`. We should be able to do that now with `onchange`.