### PR TITLE
Throws error when BG limit is increased

### DIFF
--- a/www/js/theme_editor.js
+++ b/www/js/theme_editor.js
@@ -179,6 +179,11 @@ const imageInput = themesContainer =>
           try {
             const filePath = evt.target.files[0].path;
             event.target.value = '';
+
+            if (fs.readdirSync(userBackgroundsPath).length > 4) {
+              throw new Error('Only 5 images allowed.');
+            }
+
             if (imageCheck(filePath)) {
               const files = await imagemin([filePath], userBackgroundsPath);
               if (files) {


### PR DESCRIPTION
This is another way to limit bg uploads. It throws an error after reading the file. I had some performance concerns, so I also sent a front-end only way, which I believe should be good enough for this app. 

Fixes #464 