### PR TITLE
#487 Making quick tools to overlay on the slide

### DIFF
--- a/www/src/scss/viewer.scss
+++ b/www/src/scss/viewer.scss
@@ -301,7 +301,7 @@ h2 {
 
 .viewer-controls {
   align-items: center;
-  background-color: #ccc;
+  background-color: #e0e0e0;
   display: none;
   flex-direction: column;
   height: 0;

--- a/www/src/scss/viewer.scss
+++ b/www/src/scss/viewer.scss
@@ -297,11 +297,6 @@ h2 {
   &.webview .vc-toggle-icon {
     display: flex;
   }
-
-  .deck.vc-open {
-    right: #{$viewer-padding};
-    width: calc(100% - #{$viewer-padding} * 2 - 28vh);
-  }
 }
 
 .viewer-controls {

--- a/www/src/scss/viewer.scss
+++ b/www/src/scss/viewer.scss
@@ -301,7 +301,7 @@ h2 {
 
 .viewer-controls {
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: #ccc;
   display: none;
   flex-direction: column;
   height: 0;


### PR DESCRIPTION
Fixes #487 

Making the quick tools to overlay on the slide rather than pushing the slide.

<img src="https://user-images.githubusercontent.com/5441960/53009470-50108500-3487-11e9-98a6-767b282a1128.gif"  width="600" />
