### PR TITLE
Set shallow_clone to false in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ matrix:
   fast_finish: true
 build: off
 version: '{build}'
-shallow_clone: true
+shallow_clone: false
 clone_depth: 1
 test_script:
   - npm run test && node ./packaging/release --branch=%APPVEYOR_REPO_BRANCH% --platform=win && node ./packaging/release --branch=%APPVEYOR_REPO_BRANCH% --platform=win32


### PR DESCRIPTION
This will checkout the repo in appveyor instead of downloading the zip, allowing git commands to be run. should fix
```
: Error: fatal: not a git repository (or any of the parent directories): .git
```