### PR TITLE
Fixes the vertical spacing in non presenter view. 

### DIFF
--- a/www/src/scss/_search.scss
+++ b/www/src/scss/_search.scss
@@ -179,8 +179,8 @@ button {
     text-align: left;
 
     label {
-      margin-right: 5px;
       line-height: 0;
+      margin-right: 5px;
     }
 
     input {

--- a/www/src/scss/_search.scss
+++ b/www/src/scss/_search.scss
@@ -180,6 +180,11 @@ button {
 
     label {
       margin-right: 5px;
+      line-height: 0;
+    }
+
+    input {
+      vertical-align: text-bottom;
     }
   }
 


### PR DESCRIPTION

<img width="500" alt="Screenshot 2019-04-21 at 1 33 54 PM" src="https://user-images.githubusercontent.com/1131610/56467255-226d9b00-643a-11e9-975e-e575c0433d67.png">
Fixes #465 

Vertical spacing in non presenter view looked a bit weird. However, I just realised that it's because we are mixing punjabi and english fonts which makes it look weird. I tried to fix it a little manually by eyeballing the vertical space (because in css the spacing is actually the same). 