### PR TITLE
Remaps ceremony title row to have translit and gurmukhi (Sqlite)

### DIFF
--- a/www/js/banidb/sqlite-search.js
+++ b/www/js/banidb/sqlite-search.js
@@ -193,7 +193,7 @@ const loadCeremony = CeremonyID =>
     db.all(
       `SELECT v.ID, v.Gurmukhi, v.LineNo, v.English, v.Transliteration,
       v.Visraam, v.Punjabi, v.SourceID, v.MainLetters,
-      c.Token, c.Gurmukhi as CeremonyGurmukhi,
+      c.Token, c.Gurmukhi as CeremonyGurmukhi, c.Transliteration as ceremonyTransliteration,
       cs.Custom, cs.VerseIDRangeEnd, cs.VerseIDRangeStart,
       cc.English AS ceremonyEnglish, v.PageNo 
       AS PageNo
@@ -211,7 +211,6 @@ const loadCeremony = CeremonyID =>
             const row = Object.assign({}, rawRow);
             row.Ceremony = {
               Token: row.Token,
-              Gurmukhi: row.CeremonyGurmukhi,
             };
             const customID = row.Custom;
             row.Custom = {
@@ -234,6 +233,10 @@ const loadCeremony = CeremonyID =>
 
             return row;
           });
+          if (!rowsMapped[0].Gurmukhi) {
+            rowsMapped[0].Custom.Gurmukhi = rows[0].CeremonyGurmukhi;
+            rowsMapped[0].Custom.Transliteration = rows[0].ceremonyTransliteration;
+          }
           resolve(rowsMapped);
         }
       },
@@ -326,7 +329,7 @@ const loadBani = (BaniID, BaniLength) =>
     }
     db.all(
       `SELECT v.ID, v.Gurmukhi, v.Visraam, v.MainLetters, v.English, v.Transliteration,
-      v.punjabiUni, v.punjabi,  v.SourceID, v.PageNo AS PageNo, c.Token, b.existsSGPC, b.existsMedium,
+      v.punjabiUni, v.punjabi,  v.SourceID, v.PageNo AS PageNo, c.Token, c.Gurmukhi as nameOfBani, b.existsSGPC, b.existsMedium,
       b.existsTaksal, b.existsBuddhaDal, b.MangalPosition
       FROM Verse v
       LEFT JOIN Banis_Shabad b ON v.ID = b.VerseID

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -702,7 +702,6 @@ module.exports = {
           if (rowDb.VerseIDRangeStart && rowDb.VerseIDRangeEnd) {
             row = banidb.loadVerses(rowDb.VerseIDRangeStart, rowDb.VerseIDRangeEnd);
           }
-
           row.sessionKey = `ceremony-${ceremonyID}`;
           return row;
         }),
@@ -742,7 +741,7 @@ module.exports = {
     banidb.loadBani(BaniID, baniLengthCols[baniLength]).then(rowsDb => {
       // create a unique shabadID for whole bani, and append it with length
       const shabadID = `${rowsDb[0].Token || rowsDb[0].Bani.Token}-${baniLength}`;
-      const nameOfBani = rowsDb[0].Gurmukhi || rowsDb[0].Bani.Gurmukhi;
+      const nameOfBani = rowsDb[0].nameOfBani || rowsDb[0].Bani.Gurmukhi;
       const thisBaniState = sessionStatesList[`bani-${BaniID}`];
       if (!historyReload) {
         if (thisBaniState && thisBaniState.resumePanktee && !LineID) {


### PR DESCRIPTION
On sqlite there was an issue where title row of bani did not have translit and gurmukhi counterparts, but now it does.
*Before*
<img width="1027" alt="Screenshot 2019-07-01 at 4 00 46 PM" src="https://user-images.githubusercontent.com/1131610/60473960-604e2300-9c24-11e9-829f-8dec20b2c6c5.png">
*After*
<img width="1303" alt="Screenshot 2019-07-01 at 4 26 03 PM" src="https://user-images.githubusercontent.com/1131610/60473962-6512d700-9c24-11e9-95c0-08bce37a2425.png">
