### PR TITLE
Reduces transparency for vishraams

### DIFF
--- a/www/src/scss/themes/helpers/_theme-generator.scss
+++ b/www/src/scss/themes/helpers/_theme-generator.scss
@@ -33,7 +33,7 @@
         background: linear-gradient(
           to right,
           rgba(229, 229, 229, 0) 20%,
-          rgba($visraam-main, 0.5) 100%
+          rgba($visraam-main, 0.7) 100%
         );
       }
 
@@ -41,7 +41,7 @@
         background: linear-gradient(
           to right,
           rgba(229, 229, 229, 0) 20%,
-          rgba($visraam-yamki, 0.5) 100%
+          rgba($visraam-yamki, 0.7) 100%
         );
       }
     }


### PR DESCRIPTION
Reduces transparency for vishraams by 2 points, so that gradient vishraams are more clear in themes like moody blue. 

Other than that I could not find any discrepancy between colors given by @saintsoldierx and what's in the code. 

Fixes #693 