### PR TITLE
Use black Sync icon on light themes

### DIFF
--- a/www/src/scss/themes/helpers/_light-base.scss
+++ b/www/src/scss/themes/helpers/_light-base.scss
@@ -41,6 +41,10 @@
   .viewer-controls {
     background-color: $nav-bg;
   }
+  
+  #tool-sync-button {
+    background-image: url('../../assets/img/icons/sync_button.svg');
+  }
 
   #toolbar,
   .bani-list,


### PR DESCRIPTION
Feel free to close this and replace it with another PR if this is not the correct way to fix this issue. 