### PR TITLE
Pin npm to 6.11.3 in appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - appveyor DownloadFile https://github.com/KhalisFoundation/sttm-desktop/blob/master/assets/bonjoursdksetup.exe?raw=true
   - bonjoursdksetup.exe /quiet
   - del bonjoursdksetup.exe
-  - npm install -g npm@latest
+  - npm install -g npm@6.11.3
   - set PATH=%APPDATA%\npm;%PATH%
   - npm ci
 matrix:


### PR DESCRIPTION
Appveyor is failing due to https://github.com/nodejs/node-gyp/issues/1933 


This [comment](https://github.com/nodejs/node-gyp/issues/1933#issuecomment-547472195) seems to works for us. Not my favorite solution but should unblock us temporarily.  

