### PR TITLE
removes the complex paging code

### DIFF
--- a/www/js/controller.js
+++ b/www/js/controller.js
@@ -555,18 +555,7 @@ module.exports = {
     if (document.body.classList.contains('livefeed')) {
       showLinePayload.live = true;
     }
-    // when paging, the first line gets loaded again. this makes sure obs shows the correct line.
-    if (
-      (start === 0 || start === undefined || mode === 'append') &&
-      !(
-        showLinePayload.Line.sessionKey &&
-        showLinePayload.Line.sessionKey.indexOf('ceremony') > -1 &&
-        mode === 'append' &&
-        start > 0
-      )
-    ) {
-      global.platform.ipc.send('show-line', showLinePayload);
-    }
+    global.platform.ipc.send('show-line', showLinePayload);
   },
 
   sendText(text, isGurmukhi, isAnnouncement = false) {

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -843,6 +843,7 @@ module.exports = {
 
     let seenClasses = '';
     const shabadState = sessionStatesList[line.sessionKey || `shabad-${line.ShabadID}`];
+
     if (shabadState && shabadState.resumePanktee) {
       if (shabadState.seenPanktees.has(lineSessionID) || shabadState.seenPanktees.has(line.ID)) {
         seenClasses = '.seen_check';
@@ -1082,8 +1083,10 @@ module.exports = {
       Array.from(lines).forEach(el => el.classList.remove('current'));
       // Add 'current' and 'seen-check' to selected Panktee
       $panktee.classList.add('current', 'seen_check');
-      shabadState.seenPanktees.add(`${LineID}-${Line.lineCount}`);
-      shabadState.resumePanktee = `${LineID}-${Line.lineCount}`;
+      if (shabadState) {
+        shabadState.seenPanktees.add(`${LineID}-${Line.lineCount}`);
+        shabadState.resumePanktee = `${LineID}-${Line.lineCount}`;
+      }
     }
     this.checkAutoPlay(LineID);
   },


### PR DESCRIPTION
So, this was a bit weirder than I thought. Fixes #835 

I tried to fix it in bunch of ways, which ended up feeling like hacks. Eventually, I was able to find the root cause by going through our history.  We introduced this bug when we were trying to fix the paging problem in the overlay  (#740 #691 ) Later in history, we changed the way `sessions` works and also changed the id for the ceremony (not sure), I am suspecting that caused this bug to creep up.

I removed those complex if conditions and It did the trick. I thoroughly tested to make sure that the original bugs we fixed did not resurface. As far as my testing goes, it looks good. I have created a video of going through the ceremony (anand karaj) and going through a long bani (sukhmani sahib) on overlay and second display; It works fine for me. 🤞 

 https://youtu.be/EF_MLHkf7p4

@tsingh777 as you wrote that code, you might have more insights. Can you help me test this PR in the context of those bugs as well? May be give some test recipes? There's good chance that l might be missing something in understanding those bugs. 🙏 