### PR TITLE
makes ceremony/sunder-gutka icon toggle sunder gutka and ceremonies

### DIFF
--- a/www/js/toolbar.js
+++ b/www/js/toolbar.js
@@ -33,9 +33,6 @@ const betaLabel = h('div.beta-label', 'BETA');
 
 // helper functions
 const toggleOverlayUI = (toolbarItem, show) => {
-  if (currentToolbarItem !== toolbarItem) {
-    toggleOverlayUI(currentToolbarItem, false);
-  }
   currentToolbarItem = toolbarItem;
   document.querySelectorAll('.base-ui').forEach(uiElement => {
     uiElement.classList.toggle('blur', show);
@@ -403,6 +400,9 @@ const printBanis = rows => {
 const toolbarItemFactory = toolbarItem =>
   h(`div.toolbar-item#tool-${toolbarItem}`, {
     onclick: () => {
+      if (currentToolbarItem) {
+        toggleOverlayUI(currentToolbarItem, false);
+      }
       const { databaseState } = global.core.search.$search.dataset;
       if (databaseState === 'loaded') {
         toggleOverlayUI(toolbarItem, true);


### PR DESCRIPTION
Fixes #936 

Clicking on the ceremony and sunder gutka buttons allowed you to open the screens for them. But when you clicked on them again, you expect it to close. Eaerlier, it did not do that. With this PR the button can either open or close those screens.