### PR TITLE
fixes english word search

### DIFF
--- a/www/js/banidb/realm-search.js
+++ b/www/js/banidb/realm-search.js
@@ -98,7 +98,7 @@ const query = (searchQuery, searchType, searchSource) =>
         if (searchType === 2) {
           searchCol = 'Gurmukhi';
         } else {
-          searchCol = 'English';
+          searchCol = 'Translations';
           caseInsensitive = true;
         }
         const words = saniQuery


### PR DESCRIPTION
Well `khodeya paharh nikleya chuha` :P Just had to change the name of column, which was changed a while ago in DB. However now this also means that we can search across translations, like we can write spanish word and get results for that too. 
