### PR TITLE
fixes  lock screen breaking the app bug

### DIFF
--- a/www/js/toolbar.js
+++ b/www/js/toolbar.js
@@ -180,6 +180,7 @@ const toggleAdminPin = () => {
 };
 
 const toggleLockScreen = () => {
+  toggleOverlayUI(currentToolbarItem, false);
   toggleOverlayUI('lock-screen', true);
 };
 


### PR DESCRIPTION
fixes #1000

When we changed the behviour for how toolbar items responded to double click aka closing the toolbar item when clicked on the icon again - this bug was introduced. This PR fixes it by replicating the same mechanism on the lock screen. 