### PR TITLE
removes bindGlobal

### DIFF
--- a/www/js/keyboard-shortcuts/shortcuts.js
+++ b/www/js/keyboard-shortcuts/shortcuts.js
@@ -7,7 +7,7 @@ const shortcutsApplied = {
 };
 
 const shortcutFactory = (keys, actionName) => {
-  Mousetrap.bindGlobal(keys, event => {
+  Mousetrap.bind(keys, event => {
     global.platform.ipc.send('shortcuts', { actionName, event });
     event.preventDefault();
   });


### PR DESCRIPTION
So that space bar and other keys shortcuts work only in their area.