### PR TITLE
adds green screen option to bani overlay

### DIFF
--- a/www/js/defaults.json
+++ b/www/js/defaults.json
@@ -107,7 +107,8 @@
         "translationFont": "Muli",
         "gurbaniFont": "Gurbani Akhar Thick",
         "larivaarAssist": false,
-        "theme": false
+        "theme": false,
+        "greenScreen": false
       },
       "gurbani": {
         "bottom": 156,

--- a/www/js/overlay.js
+++ b/www/js/overlay.js
@@ -245,6 +245,10 @@ const overlayUrl = () =>
     copyURLButton,
   );
 
+const changeOpacityButton = resizeButtonFactory(increaseOpacity, decreaseOpacity);
+const opacityControls = controlsFactory(changeOpacityButton, i18n.t('BANI_OVERLAY.OPACITY'));
+opacityControls.style.display = overlayVars.greenScreen ? 'none' : 'inline-block';
+
 const toggleLarivaarAssist = h(
   'div.input-wrap.larivaar-assist-toggle',
   {
@@ -403,10 +407,33 @@ const toggleAnnouncements = h(
   h('div.setting-label', i18n.t('BANI_OVERLAY.ANNOUNCEMENT')),
 );
 
+const toggleGreenScreen = h(
+  'div.input-wrap.green-screen-toggle',
+  {
+    onclick: evt => {
+      if (overlayCast) {
+        overlayVars.greenScreen = !overlayVars.greenScreen;
+        savePrefs();
+        const { greenScreen } = overlayVars;
+
+        setToggleIcon(evt.currentTarget, greenScreen);
+        opacityControls.style.display = greenScreen ? 'none' : 'inline-block';
+        analytics.trackEvent('overlay', 'toggleGreenScreen', greenScreen);
+      }
+    },
+  },
+  h(
+    'div#green-screen-btn',
+    h(`i.fa.cp-icon.${overlayVars.greenScreen ? 'fa-toggle-on' : 'fa-toggle-off'}`),
+  ),
+  h('div.setting-label', i18n.t('BANI_OVERLAY.GREEN_SCREEN')),
+);
+
 /** Main Control Bar Items */
 controlPanel.append(toggleCast);
 controlPanel.append(toggleLogo);
 controlPanel.append(toggleAnnouncements);
+controlPanel.append(toggleGreenScreen);
 controlPanel.append(separator);
 controlPanel.append(resetButton);
 controlPanel.append(toggleLarivaar);
@@ -434,7 +461,6 @@ const changeGurbanifontSizeButton = resizeButtonFactory(
   increaseGurbanifontSize,
   decreaseGurbanifontSize,
 );
-const changeOpacityButton = resizeButtonFactory(increaseOpacity, decreaseOpacity);
 
 const translationFonts = fontListFactory(fonts.translation, 'translationFont');
 const gurbaniFonts = fontListFactory(fonts.gurbani, 'gurbaniFont');
@@ -453,7 +479,7 @@ textControls.append(separatorY());
 textControls.append(controlsFactory(backgroundColor, i18n.t('BANI_OVERLAY.BG')));
 textControls.append(separatorY());
 textControls.append(controlsFactory(changeBarSizeButton, i18n.t('BANI_OVERLAY.SIZE')));
-textControls.append(controlsFactory(changeOpacityButton, i18n.t('BANI_OVERLAY.OPACITY')));
+textControls.append(opacityControls);
 textControls.append(separatorY());
 textControls.append(
   controlsFactory(

--- a/www/locales/en.json
+++ b/www/locales/en.json
@@ -31,7 +31,8 @@
     "PADCHED": "Padched",
     "PRESETS": "Presets",
     "SIZE": "Size",
-    "TEXT": "Text"
+    "TEXT": "Text",
+    "GREEN_SCREEN": "Green Screen"
   },
 
   "CHROMECAST": {

--- a/www/obs/index.html
+++ b/www/obs/index.html
@@ -89,13 +89,17 @@
       };
 
       var applyOverlayPrefs = function() {
+        const overlayColor = overlayPrefs.overlayVars.greenScreen ? '#0f0' : 'transparent';
+        const bgOpacity =
+          Number(overlayPrefs.overlayVars.greenScreen) || overlayPrefs.overlayVars.bgOpacity;
+
         document.querySelectorAll('.content-top, .content-bottom').forEach(el => {
           el.style.color = overlayPrefs.overlayVars.textColor;
           el.style.fontSize = `${overlayPrefs.overlayVars.fontSize}vh`;
           el.style.padding = `${overlayPrefs.overlayVars.padding}vh`;
-          el.style.backgroundColor = `rgba(${hexToRgb(overlayPrefs.overlayVars.bgColor)}, ${
-            overlayPrefs.overlayVars.bgOpacity
-          })`;
+          el.style.backgroundColor = `rgba(${hexToRgb(
+            overlayPrefs.overlayVars.bgColor,
+          )}, ${bgOpacity})`;
         });
 
         document.querySelector('.logo-wrapper').style.opacity = overlayPrefs.overlayVars.bgOpacity;
@@ -130,9 +134,9 @@
           });
           document.querySelector('.overlay-wrapper').style.backgroundColor = 'transparent';
           // Apply the background color from theme
-          el.style.backgroundColor = `rgba(${hexToRgb(overlayPrefs.overlayVars.bgColor)}, ${
-            overlayPrefs.overlayVars.bgOpacity
-          })`;
+          el.style.backgroundColor = `rgba(${hexToRgb(
+            overlayPrefs.overlayVars.bgColor,
+          )}, ${bgOpacity})`;
         });
 
         // Special style overrides for vertical layout
@@ -146,9 +150,9 @@
               content.style.padding = '0';
             });
             el.style.width = `${overlayPrefs.overlayVars.padding} * 10%`;
-            el.style.backgroundColor = `rgba(${hexToRgb(overlayPrefs.overlayVars.bgColor)}, ${
-              overlayPrefs.overlayVars.bgOpacity
-            })`;
+            el.style.backgroundColor = `rgba(${hexToRgb(
+              overlayPrefs.overlayVars.bgColor,
+            )}, ${bgOpacity})`;
           });
 
         // Special style overrides for classic layout
@@ -156,9 +160,9 @@
           .querySelectorAll('.layout-classic .content-top, .layout-classic .content-bottom')
           .forEach(el => {
             el.style.backgroundColor = 'transparent';
-            const overlayBgColor = `rgba(${hexToRgb(overlayPrefs.overlayVars.bgColor)}, ${
-              overlayPrefs.overlayVars.bgOpacity
-            })`;
+            const overlayBgColor = `rgba(${hexToRgb(
+              overlayPrefs.overlayVars.bgColor,
+            )}, ${bgOpacity})`;
             el.style.padding = '0';
             document.querySelectorAll('span.o-gurbani, span.o-translation').forEach(spanEl => {
               spanEl.style.backgroundColor = overlayBgColor;
@@ -166,6 +170,8 @@
             });
             document.querySelector('.overlay-wrapper').style.backgroundColor = 'transparent';
           });
+
+        document.body.style.backgroundColor = overlayColor;
 
         const $gurbani = document.querySelector('.o-gurbani');
         const { overlayLarivaar, larivaarAssist } = overlayPrefs.overlayVars;

--- a/www/src/scss/_overlay.scss
+++ b/www/src/scss/_overlay.scss
@@ -244,7 +244,8 @@ input[type='color'] {
 
   .logo-toggle,
   .announcement-toggle,
-  .larivaar-assist-toggle {
+  .larivaar-assist-toggle,
+  .green-screen-toggle {
     .fa-toggle-off,
     .fa-toggle-on {
       cursor: not-allowed;
@@ -257,7 +258,8 @@ input[type='color'] {
 .cast-toggle,
 .logo-toggle,
 .announcement-toggle,
-.larivaar-assist-toggle {
+.larivaar-assist-toggle,
+.green-screen-toggle {
   cursor: pointer;
   .cp-icon {
     font-size: 34px;


### PR DESCRIPTION
Fixes #1088 

https://youtu.be/eo8HeExaVwI

Adds a toggle for the Green Screen. When green screen is on, we switch off the opacity options. 