### PR TITLE
fixes QR Code styling

### DIFF
--- a/www/src/scss/styles.scss
+++ b/www/src/scss/styles.scss
@@ -400,6 +400,7 @@ a {
 
   .sync-content-wrapper {
     border-radius: 5px;
+    position: relative;
     .sync-content {
       opacity: 1;
     }

--- a/www/src/scss/styles.scss
+++ b/www/src/scss/styles.scss
@@ -504,6 +504,7 @@ a {
     position: absolute;
     right: -220px;
     text-align: center;
+    top: 0;
     width: 200px;
 
     .qr-desc {


### PR DESCRIPTION
Some styling might have changed during merge into beta which caused QR code to hide behind sync dialogue. This should fix it.
