### PR TITLE
Fixes zoom overlay ui cut off

### DIFF
--- a/www/main/navigator.jsx
+++ b/www/main/navigator.jsx
@@ -19,13 +19,15 @@ export const Navigator = () => {
         </div>
 
         <div className="sync-dialogue-wrapper hidden overlay-ui ui-sync-button">
-          <div className="zoom-dialogue hidden overlay-ui ui-sync-button">
-            <img class="zoom-logo" src="assets/img/icons/zoom.svg" />
-            <header className="sync-header" data-key="ZOOM_HEADING"></header>
-          </div>
+          <div className="sync-dialogue-container">
+            <div className="zoom-dialogue hidden overlay-ui ui-sync-button">
+              <img class="zoom-logo" src="assets/img/icons/zoom.svg" />
+              <header className="sync-header" data-key="ZOOM_HEADING"></header>
+            </div>
 
-          <div className="sync-dialogue hidden overlay-ui ui-sync-button">
-            <header className="sync-header" data-key="MOBILE_DEVICE_SYNC"></header>
+            <div className="sync-dialogue hidden overlay-ui ui-sync-button">
+              <header className="sync-header" data-key="MOBILE_DEVICE_SYNC"></header>
+            </div>
           </div>
         </div>
 

--- a/www/src/scss/styles.scss
+++ b/www/src/scss/styles.scss
@@ -396,7 +396,7 @@ a {
 
   .sync-dialogue {
     margin-bottom: 20px;
-    max-width: 600px;
+    max-width: 500px;
   }
 
   .sync-content-wrapper {
@@ -615,6 +615,11 @@ a {
   position: fixed;
   top: 0;
   width: calc(100% - 100px);
+
+  .sync-dialogue-container {
+    overflow: auto;
+    width: 100%;
+  }
 
   &.hidden {
     display: none;


### PR DESCRIPTION
Haven't tested it on windows yet, but added a scrollbar for smaller screens.

![Peek 2020-09-24 12-27](https://user-images.githubusercontent.com/1990932/94111142-49b36d80-fe61-11ea-97ae-3ea45f228969.gif)
