### PR TITLE
Removes border from viewer window

### DIFF
--- a/app.js
+++ b/app.js
@@ -453,7 +453,7 @@ app.on('ready', () => {
     minHeight: 600,
     width,
     height,
-    frame: process.platform !== 'win32',
+    frame: false,
     show: false,
     backgroundColor: '#000000',
     titleBarStyle: 'hidden',

--- a/app.js
+++ b/app.js
@@ -258,7 +258,7 @@ function createViewer(ipcData) {
       autoHideMenuBar: true,
       show: false,
       titleBarStyle: 'hidden',
-      frame: process.platform !== 'win32',
+      frame: false,
       backgroundColor: '#000000',
       webPreferences: {
         nodeIntegration: true,


### PR DESCRIPTION
I wasn't sure why we were showing border in windows only, I set it to false to not show border anywhere. 

Fixes #1236 