### PR TITLE
removes write file from getSavedUserSettings

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,13 +11,6 @@ const i18nBackend = require('i18next-node-fs-backend');
 const os = require('os');
 const fetch = require('node-fetch');
 
-/* eslint-disable import/no-unresolved */
-const Store = require('./www/js/store.js');
-const {
-  savedSettingsCamelCase,
-} = require('./www/js/common/store/user-settings/get-saved-user-settings');
-/* eslint-enable */
-
 const defaultPrefs = require('./www/configs/defaults.json');
 const themes = require('./www/configs/themes.json');
 const Analytics = require('./analytics');
@@ -31,6 +24,13 @@ const expressApp = express();
 const httpBase = require('http').Server(expressApp);
 const http = require('http-shutdown')(httpBase);
 const io = require('socket.io')(http);
+/* eslint-enable */
+
+/* eslint-disable import/no-unresolved */
+const Store = require('./www/js/store.js');
+const {
+  savedSettingsCamelCase,
+} = require('./www/js/common/store/user-settings/get-saved-user-settings');
 /* eslint-enable */
 
 const savedSettings = savedSettingsCamelCase();

--- a/www/main/common/store/user-settings/get-saved-user-settings.js
+++ b/www/main/common/store/user-settings/get-saved-user-settings.js
@@ -20,7 +20,6 @@ function parseDataFile(filePath) {
     Object.keys(settings).forEach(key => {
       defaultSettings[key] = settings[key].initialValue;
     });
-    fs.writeFileSync(userConfigPath, JSON.stringify(defaultSettings));
     return defaultSettings;
   }
 }


### PR DESCRIPTION
There was error on fresh install of 8.3 saying that user data did not exist. Fixed that error with this code change.

Earlier getSavedUserSettings, used to write the defaults to the file,if it didn't exist.. using writeFileSync, I realized that it's not needed because we are already writing to file in setUserSettingsState. 