### PR TITLE
Fixes presenter view switch on refresh

### DIFF
--- a/www/main/controller.js
+++ b/www/main/controller.js
@@ -470,6 +470,7 @@ global.platform.ipc.on('external-display', (e, args) => {
     width: args.width,
     height: args.height,
   };
+  checkPresenterView();
   updateViewerScale();
 });
 global.platform.ipc.on('remove-external-display', () => {


### PR DESCRIPTION
When external display is connected, it switches to single window mode on refresh. This fixes it.