### PR TITLE
Fix viewer padding issue on windows single display mode

### DIFF
--- a/www/main/viewer/ShabadDeck/ShabadDeck.jsx
+++ b/www/main/viewer/ShabadDeck/ShabadDeck.jsx
@@ -11,6 +11,9 @@ import {
 } from '../../navigator/utils';
 import ViewerIcon from '../icons/ViewerIcon';
 
+const os = require('os');
+
+const platform = os.platform();
 const themes = require('../../../../www/configs/themes.json');
 
 function ShabadDeck() {
@@ -157,9 +160,9 @@ function ShabadDeck() {
       <div
         className={`shabad-deck ${akhandpatt ? 'akhandpatt-view' : ''} ${
           miscSlideText === '' ? 'empty-slide' : ''
-        } ${isSingleDisplayMode ? 'single-display-mode' : ''} theme-${
-          getCurrentThemeInstance().key
-        }`}
+        } ${isSingleDisplayMode ? 'single-display-mode' : ''} ${
+          platform === 'win32' ? 'win32' : ''
+        } theme-${getCurrentThemeInstance().key}`}
         style={applyTheme()}
       >
         {/* show quicktools only on presentation mode */}

--- a/www/src/scss/viewer/shabad-deck/_shabad-deck.scss
+++ b/www/src/scss/viewer/shabad-deck/_shabad-deck.scss
@@ -17,6 +17,10 @@
 
   &.single-display-mode {
     padding: 24px 72px;
+
+    &.win32 {
+      padding-top: 56px;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes #1405

The approach I used is by adding win32 class to the viewer when it's on windows and then adding padding-top on windows only. I am not sure if we need to do this on mac or not. Although It was written we need to do it on windows.

![image](https://user-images.githubusercontent.com/38748298/149499619-62d8f1ad-57e5-46fc-be6d-c16196ea0116.png)
