### PR TITLE
build: change husky prepush lint to precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,8 +186,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged",
-      "pre-push": "npm test"
+      "pre-commit": "pretty-quick --staged && npm test"
     }
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR changes the `npm test` which is `run-p test:*` associated with the Husky pre-push hook to pre-commit. 