### PR TITLE
fix: hide the quick tools from external viewer window

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,6 +274,9 @@ function createViewer(ipcData) {
     });
     viewerWindow.loadURL(`file://${__dirname}/www/viewer.html`);
     viewerWindow.webContents.on('did-finish-load', () => {
+      viewerWindow.webContents.insertCSS(
+        '.slide-quicktools { display: none; } .verse-slide { padding-top: 40px !IMPORTANT }',
+      );
       viewerWindow.show();
       const [width, height] = viewerWindow.getSize();
       mainWindow.webContents.send('external-display', {


### PR DESCRIPTION
![Screenshot from 2022-04-18 23-56-20](https://user-images.githubusercontent.com/1990932/163855874-f10288e9-1961-4354-bf99-8ba7bd0489e1.png)