### PR TITLE
fix: spacing issue on chromecast window

### DIFF
--- a/LEGEND.md
+++ b/LEGEND.md
@@ -36,6 +36,7 @@
 | CMD + G                                                                          | Add Dhan slide or announcement              |
 | Spacebar (when in a shabad)                                                      | Switch between main line and unchecked line |
 | Spacebar (when a special slide [ie waheguru slide, announcement, etc] is active) | Switch back to shabad                       |
+| CMD + ALT + C                                                                    | Search for chromecast devices               |
 
 #### <a name="windows-slides">Windows:</a>
 
@@ -51,6 +52,7 @@
 | CTRL + G                                                                         | Add Dhan slide or announcement              |
 | Spacebar (when in a shabad)                                                      | Switch between main line and unchecked line |
 | Spacebar (when a special slide [ie waheguru slide, announcement, etc] is active) | Switch back to shabad                       |
+| CTRL + ALT + C                                                                   | Search for chromecast devices               |
 
 ### <a name="others">Others</a>
 

--- a/www/main/controller.js
+++ b/www/main/controller.js
@@ -137,6 +137,7 @@ const menuTemplate = [
     submenu: [
       {
         label: i18n.t('MENU.CAST.SEARCH'),
+        accelerator: 'CmdOrCtrl+Alt+C',
         click: () => {
           global.webview.send('search-cast');
         },

--- a/www/main/viewer/Slide/Slide.jsx
+++ b/www/main/viewer/Slide/Slide.jsx
@@ -70,6 +70,9 @@ const Slide = ({ verseObj, nextLineObj, isMiscSlide }) => {
                   activeVerseId === verseObj.ID ? 'active-viewer-verse' : ''
                 }`}
                 ref={activeVerseRef}
+                style={{
+                  'font-weight': 'normal', // adding style here to reach chromecast
+                }}
               >
                 <SlideGurbani
                   getFontSize={getFontSize}

--- a/www/main/viewer/hooks/bakePanktee.js
+++ b/www/main/viewer/hooks/bakePanktee.js
@@ -44,10 +44,21 @@ const bakePanktee = () => {
     };
 
     const bakePankteeMarkup = () => {
-      // need to set <wbr /> according to larivaar on and off
+      let customStyles;
+      if (larivaar) {
+        customStyles = getFontSize(gurbaniFontSize);
+      } else {
+        // adding custom styles here to reach chromecast
+        customStyles = {
+          ...getFontSize(gurbaniFontSize),
+          display: 'inline-block',
+          margin: '0 0.15em',
+          'white-space': 'nowrap',
+        };
+      }
       return breakIntoWords(gurmukhiString).map((word, i) => (
         <React.Fragment key={i}>
-          <span className={getVishraamStyle(word)} style={getFontSize(gurbaniFontSize)}>
+          <span className={getVishraamStyle(word)} style={customStyles}>
             {word.text}
           </span>
           <wbr />


### PR DESCRIPTION
- add a keybord shortcut to search for chromecast devices
We can now use Ctrl/Cmd + Alt + C to open the chromecast search window.

Fixes issue #1632 