### PR TITLE
Bug fixes after 9.1.1 alpha release QA

### DIFF
--- a/www/configs/shortcuts-map.json
+++ b/www/configs/shortcuts-map.json
@@ -7,8 +7,10 @@
   "legend": ["mod+6"],
   "searchBar": ["mod+/"],
   "showDhanGuruModal": ["mod+g"],
-  "prevLine": ["up", "left"],
-  "nextLine": ["down", "right"],
+  "prevLine": ["left"],
+  "prevLineUp": ["up"],
+  "nextLine": ["right"],
+  "nextLineDown": ["down"],
   "homePanktee": ["space"],
   "copyPanktee": ["mod+c"],
   "openFirstResult": ["enter"]

--- a/www/main/common/sttm-ui/inputbox/InputBox.jsx
+++ b/www/main/common/sttm-ui/inputbox/InputBox.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 const remote = require('@electron/remote');
 import { searchShabads, loadAng } from '../../../navigator/utils';
+import { InputContext } from '../../../launchpad';
 
 const analytics = remote.getGlobal('analytics');
 
@@ -12,7 +13,7 @@ const InputBox = ({ placeholder, disabled, className, databaseProgress, query, s
   );
   const { setSearchData, setShortcuts } = useStoreActions(state => state.navigator);
 
-  const inputRef = useRef(null);
+  const inputContextRef = useContext(InputContext);
   const handleChange = event => {
     setQuery(event.target.value);
   };
@@ -25,7 +26,7 @@ const InputBox = ({ placeholder, disabled, className, databaseProgress, query, s
 
   // keyboard shortcut to focus on search input
   const focusInputbox = () => {
-    inputRef.current.focus();
+    inputContextRef.current.focus();
   };
 
   const sendAnalytics = () => {
@@ -61,7 +62,7 @@ const InputBox = ({ placeholder, disabled, className, databaseProgress, query, s
       <input
         className={`input-box ${className}`}
         type="search"
-        ref={inputRef}
+        ref={inputContextRef}
         placeholder={placeholder}
         value={query}
         onBlur={sendAnalytics}

--- a/www/main/keyboard-shortcuts/shortcuts.js
+++ b/www/main/keyboard-shortcuts/shortcuts.js
@@ -9,7 +9,10 @@ const shortcutsApplied = {
 const shortcutFactory = (keys, actionName) => {
   Mousetrap.bind(keys, (event) => {
     global.platform.ipc.send('shortcuts', JSON.stringify({ actionName, event }));
-    event.preventDefault();
+    // prevents the default action for all keys, except left and right arrow keys
+    if (!['left', 'right'].some(k => keys.includes(k))) {
+      event.preventDefault();
+    }
   });
 };
 

--- a/www/main/launchpad/index.js
+++ b/www/main/launchpad/index.js
@@ -1,1 +1,2 @@
 export { default } from './Launchpad';
+export { InputContext } from './Launchpad';

--- a/www/main/navigator/shabad/ShabadContent.jsx
+++ b/www/main/navigator/shabad/ShabadContent.jsx
@@ -197,6 +197,7 @@ const ShabadContent = () => {
         if (mappedShabadArray.length - 1 > parseInt(activeVerseIndex, 10)) {
           const newVerseIndex = parseInt(activeVerseIndex, 10) + 1;
           const newVerseId = mappedShabadArray[newVerseIndex].verseId;
+          scrollToVerse(newVerseId);
           updateTraversedVerse(newVerseId, newVerseIndex);
         }
       });
@@ -243,7 +244,9 @@ const ShabadContent = () => {
   };
 
   const toggleHomeVerse = () => {
-    if (homeVerse >= 0) {
+    if (isSundarGutkaBani || isCeremonyBani) {
+      openNextVerse();
+    } else if (homeVerse) {
       const mappedShabadArray = filterRequiredVerseItems(activeShabad);
       const currentVerseIndex = mappedShabadArray.findIndex(
         ({ verseId }) => verseId === activeVerseId,


### PR DESCRIPTION
- Fix the app crash on pressing space key
- Restore the default behavior of left/right arrow keys inside search text box
- Trigger the keyboard shortcuts only when the search box is not in focus
- Run the Enter keyboard shortcut on pressing numpad enter key as well
- In sundar gutka and ceremony mode, the space bar will continue to next verse without coming back to home verse.

This fixes issue #1743 #1741 #1740 