### PR TITLE
shabad verse tick fix

### DIFF
--- a/www/main/navigator/shabad/ShabadContent.jsx
+++ b/www/main/navigator/shabad/ShabadContent.jsx
@@ -145,6 +145,10 @@ const ShabadContent = () => {
         verseHistory[currentIndex].versesRead = [...versesRead, newTraversedVerse];
         setVersesRead([...versesRead, newTraversedVerse]);
       }
+    } else {
+      if (!versesRead.some((traversedVerse) => traversedVerse === newTraversedVerse)) {
+        setVersesRead([...versesRead, newTraversedVerse]);
+      }
     }
     setActiveVerse({ [verseIndex]: newTraversedVerse });
     if (activeVerseId !== newTraversedVerse) {


### PR DESCRIPTION
In the shabad pane, when we click on the right arrow, it opens a new shabad. Once we click on a shabad verse, it starts reading the shabad verse but doesn't show the tick on that read shabad verse. 
In this PR, I fixed the issue and now it is successfully showing tick on read shabad verse.