### PR TITLE
fix: search result size when filter applied

### DIFF
--- a/www/src/scss/navigator/search/_searchNew.scss
+++ b/www/src/scss/navigator/search/_searchNew.scss
@@ -220,7 +220,7 @@
     height: calc(100% - 40px);
 
     &.filter-applied {
-      height: calc(100% - 150px);
+      height: calc(100% - 62px);
     }
   }
   .gurmukhi-keyboard + .search-result-controls + .search-results {


### PR DESCRIPTION
Fix this issue of size when filter is applied 
![image](https://github.com/KhalisFoundation/sttm-desktop/assets/38748298/a760da50-7656-41bb-9256-a08ff995b0b1)
