### PR TITLE
release(9.1.2): changelog for  and bump up version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## New Updates
 
+### 9.1.2 - _June 13, 2023_
+
+#### Enhancements
+
+- UI overhaul of Dhan Guru slides, Quick tray, and Announcements Tab
+
+#### Improvements
+
+- Fix the warning of malicious software for MacOS
+- Fix issues with marking verses as read
+- Fix scroll issues with Announcement tab
+- Other minor issues
+
+</br>
+
+**We would love to hear from you if there a feature that you have been waiting for. Send us your feedback at [sttm.co/feedback](https://www.sttm.co/feedback).**
+
+</br>
+
 ### 9.1.1 - _April 25, 2023_
 
 #### Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sttm-desktop",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sttm-desktop",
-      "version": "9.1.1",
+      "version": "9.1.2",
       "hasInstallScript": true,
       "license": "OSL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "productName": "SikhiToTheMax",
   "name": "sttm-desktop",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "The SikhiToTheMax desktop app",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
### 9.1.2 - _June 13, 2023_

#### Enhancements

- UI overhaul of Dhan Guru slides, Quick tray, and Announcements Tab

#### Improvements

- Fix the warning of malicious software for MacOS
- Fix issues with marking verses as read
- Fix scroll issues with Announcement tab
- Other minor issues