### PR TITLE
build(.travis.yml): add console output to avoid build termination

### DIFF
--- a/packaging/release
+++ b/packaging/release
@@ -33,11 +33,16 @@ const release = async () => {
 
   console.log('TODO: stream output for the next command');
   console.log(`npm run dist:${platform}`);
+
   try {
-    const { stdout } = await exec(`npm run dist:${platform}`);
-    console.log(stdout);
-  } catch (e) {
-    console.log(e);
+    setTimeout(() => {
+      console.log(`npm run dist:${platform} is taking a long time, please wait...`);
+    }, 590000);
+    const { stdout, stderr } = await exec(`npm run dist:${platform}`);
+    console.log('stdout:', stdout);
+    console.log('stderr:', stderr);
+  } catch (err) {
+    console.error(err);
   }
 
   // Only push git tag if on Travis


### PR DESCRIPTION
Add an output on console after 9mins and 50 seconds of execution to give some extra time to npm run dist command. 