### PR TITLE
Remove aftersign hook from windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
   "build": {
     "appId": "org.khalisfoundation.sttm",
     "copyright": "Copyright © 2022 Khalis Foundation , SikhiToTheMax Trademark SHARE Charity, UK\n",
-    "afterSign": "packaging/afterSignHook.js",
     "files": [
       "**/*",
       "!assets${/*}",
@@ -165,6 +164,7 @@
       "category": "public.app-category.reference",
       "icon": "assets/STTM.icns",
       "hardenedRuntime": true,
+      "afterSign": "packaging/afterSignHook.js",
       "entitlements": "./entitlements.mac.inherit.plist",
       "target": [
         "dmg",


### PR DESCRIPTION
Currently windows appveyor is not running, because of @electron/notarize plugin, which is used by mac build. Removing it from windows build, since we dont have certificates setup here.