### PR TITLE
Resolve the code sign error in mac build and minor style fixes

### DIFF
--- a/entitlements.mac.inherit.plist
+++ b/entitlements.mac.inherit.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/www/src/scss/controller.scss
+++ b/www/src/scss/controller.scss
@@ -246,7 +246,7 @@ ul {
     align-items: center;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: space-evenly;
     position: relative;
     width: 50vw;
   }

--- a/www/src/scss/navigator/misc/_misc.scss
+++ b/www/src/scss/navigator/misc/_misc.scss
@@ -6,6 +6,10 @@ $misc-footer-active: 70px;
 
 .misc-pane {
   @include pane-containers;
+  .pane-header {
+    display: block;
+  }
+
   .misc-header {
     display: inline-flex;
     width: 100%;

--- a/www/src/scss/styles.scss
+++ b/www/src/scss/styles.scss
@@ -760,6 +760,9 @@ button {
 }
 
 .auth-wrapper {
+  bottom: 40px;
+  height: initial;
+
   .auth-content {
     align-items: flex-start;
 


### PR DESCRIPTION
The keytar library used is not signed so I disabled library validation for now. We can explore if we want to use an alternate library in the next release.

Also, found few mac related style issues, which are fixed in this PR.