### PR TITLE
fix: Ensure numeric operations for font size adjustments

### DIFF
--- a/www/main/viewer/Slide/QuickTools.jsx
+++ b/www/main/viewer/Slide/QuickTools.jsx
@@ -92,9 +92,9 @@ const QuickTools = ({ isMiscSlide }) => {
     if (name === 'visibility') {
       payload = !userSettings[stateName];
     } else if (name === 'minus') {
-      payload = userSettings[stateName] - 1;
+      payload = parseInt(userSettings[stateName], 10) - 1;
     } else if (name === 'plus') {
-      payload = userSettings[stateName] + 1;
+      payload = parseInt(userSettings[stateName], 10) + 1;
     }
     return {
       actionName,


### PR DESCRIPTION
Fixed a bug where `userSettings[stateName]` was treated as a string, leading to string concatenation instead of arithmetic addition when adjusting font sizes. For example, adding 1 to a font size of '9' resulted in '91' instead of 10. The solution implemented parses `userSettings[stateName]` as an integer before performing the addition.