### PR TITLE
Update the electron notarize to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@babel/plugin-transform-runtime": "^7.22.15",
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-react": "^7.22.15",
-        "@electron/notarize": "^2.1.0",
+        "@electron/notarize": "^2.3.2",
         "concurrently": "^8.2.1",
         "cross-env": "^7.0.3",
         "electron": "^26.2.4",
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@electron/notarize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.1.0.tgz",
-      "integrity": "sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.3.2.tgz",
+      "integrity": "sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -3702,6 +3702,35 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/notarize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.1.0.tgz",
+      "integrity": "sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
@@ -27158,9 +27187,9 @@
       }
     },
     "@electron/notarize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.1.0.tgz",
-      "integrity": "sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.3.2.tgz",
+      "integrity": "sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -28398,6 +28427,31 @@
         "temp-file": "^3.4.0"
       },
       "dependencies": {
+        "@electron/notarize": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.1.0.tgz",
+          "integrity": "sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "fs-extra": "^9.0.1",
+            "promise-retry": "^2.0.1"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            }
+          }
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/plugin-transform-runtime": "^7.22.15",
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.22.15",
-    "@electron/notarize": "^2.1.0",
+    "@electron/notarize": "^2.3.2",
     "concurrently": "^8.2.1",
     "cross-env": "^7.0.3",
     "electron": "^26.2.4",

--- a/packaging/afterSignHook.js
+++ b/packaging/afterSignHook.js
@@ -23,8 +23,6 @@ module.exports = async (params) => {
 
   try {
     await notarize({
-      tool: 'notarytool',
-      appBundleId: appId,
       appPath,
       appleId: process.env.APPLE_ID,
       appleIdPassword: process.env.APPLE_ID_PASSWORD,


### PR DESCRIPTION
Removing the appbundleId from the options, as it is no longer supported in latest version.