### PR TITLE
Skip the checkVersion condition for macArm architecture

### DIFF
--- a/packaging/release
+++ b/packaging/release
@@ -20,7 +20,7 @@ const release = async () => {
   }
 
   // win-ia32 and macArm is run on the same machine right after win-x64, so don't update the version
-  if (platform !== 'win32' || platform !== 'macArm') {
+  if (platform !== 'win32' && platform !== 'macArm') {
     // Get all tags, sort in desc order, and get latest from current track
     const gitTags = await git().tags();
     const gitTag = gitTags.all.reverse().find((tag) => tag.indexOf(track) > -1);


### PR DESCRIPTION
Skip checking the version, when running the build for mac arm, as it would already be updated when doing for mac.