### PR TITLE
When searching for ੳ, it also show results for ਓ 

### DIFF
--- a/www/main/banidb/constants.js
+++ b/www/main/banidb/constants.js
@@ -38,6 +38,15 @@ const SOURCE_TYPES = {
   REHATNAMAS: 'R',
 };
 
+const BINDI_CHARS = {
+  '103': '090', //  ਗ: 'ਗ਼'
+  '106': '122', //  ਜ: 'ਜ਼'
+  '115': '083', //  ਸ: 'ਸ਼'
+  '075': '094', //  ਖ: 'ਖ਼'
+  '080': '038', //  ਫ: 'ਫ਼'
+  '097': '069', //  ੳ : ਓ
+};
+
 const SOURCE_TEXTS = {
   [SOURCE_TYPES.ALL_SOURCES]: 'ALL_SOURCES',
   [SOURCE_TYPES.GURU_GRANTH_SAHIB]: 'GURU_GRANTH_SAHIB',
@@ -56,4 +65,5 @@ module.exports = {
   SEARCH_TEXTS,
   SOURCE_TEXTS,
   SOURCE_TYPES,
+  BINDI_CHARS,
 };

--- a/www/main/banidb/realm-search.js
+++ b/www/main/banidb/realm-search.js
@@ -37,6 +37,8 @@ const init = () => {
   }
 };
 
+const hasBindiCharacter = (charCode) => CONSTS.BINDI_CHARS[charCode] || false;
+
 /**
  * Retrieve lines matching queries
  *
@@ -84,11 +86,19 @@ const query = (searchQuery, searchType, searchSource, resultRows = 20) =>
           }
         }
 
-        // Replace kh with kh pair bindi
         let replaced = '';
-        if (dbQuery.includes('075')) {
-          replaced = `OR ${searchCol} ${operator} '${dbQuery.replace(/075/g, '094')}'`;
+        let newQuery = '';
+        const dbQueryArray = dbQuery.split(',');
+        dbQueryArray.forEach((charCode) => {
+          const bindiCharCode = hasBindiCharacter(charCode);
+          if (bindiCharCode) {
+            newQuery = dbQuery.replaceAll(charCode, bindiCharCode);
+          }
+        });
+        if (newQuery) {
+          replaced = `OR ${searchCol} ${operator} '${newQuery}'`;
         }
+
         if (isWildChar) {
           dbQuery =
             searchType === CONSTS.SEARCH_TYPES.FIRST_LETTERS ? `${dbQuery}*` : `*${dbQuery}*`;

--- a/www/main/navigator/search/components/SearchContent.jsx
+++ b/www/main/navigator/search/components/SearchContent.jsx
@@ -53,6 +53,7 @@ const SearchContent = () => {
   const [raagArray, setRaagArray] = useState([]);
   const [sourceArray, setSourceArray] = useState([]);
   const [searchResultsCount, setSearchResultsCount] = useState(40);
+  const [searchPending, setSearchPending] = useState(true);
 
   const sourcesObj = banidb.SOURCE_TEXTS;
   const writersObj = banidb.WRITER_TEXTS;
@@ -72,17 +73,20 @@ const SearchContent = () => {
   };
 
   const loadMoreSearchResults = useCallback(() => {
-    setTimeout(() => {
-      setSearchResultsCount(searchResultsCount + 20);
-      searchShabads(query, currentSearchType, currentSource, searchResultsCount).then(
-        (rows) => query && rows.length && setSearchData(rows),
-      );
-      analytics.trackEvent({
-        category: 'search',
-        action: 'load-more-search-results',
-        value: searchResultsCount,
-      });
-    }, 200);
+    if (searchPending) {
+      setTimeout(() => {
+        setSearchResultsCount(searchResultsCount + 20);
+        searchShabads(query, currentSearchType, currentSource, searchResultsCount).then((rows) => {
+          if (!rows.length) setSearchPending(false);
+          return query && rows.length && setSearchData(rows);
+        });
+        analytics.trackEvent({
+          category: 'search',
+          action: 'load-more-search-results',
+          value: searchResultsCount,
+        });
+      }, 200);
+    }
   });
   const mapVerseItems = (searchedShabadsArray) =>
     searchedShabadsArray


### PR DESCRIPTION
Mapped all characters with their bindi characters

```javascript
const BINDI_CHARS = {
  '103': '090', //  ਗ: 'ਗ਼'
  '106': '122', //  ਜ: 'ਜ਼'
  '115': '083', //  ਸ: 'ਸ਼'
  '075': '094', //  ਖ: 'ਖ਼'
  '080': '038', //  ਫ: 'ਫ਼'
  '097': '069', //  ੳ : ਓ
};
```

When searching for ਗ, it would also include ਗ਼

Fixes issue #993 