### PR TITLE
Make first letter english search to do a case insensitive comparision

### DIFF
--- a/www/main/banidb/realm-search.js
+++ b/www/main/banidb/realm-search.js
@@ -169,7 +169,7 @@ const query = (searchQuery, searchType, searchSource, resultRows = 20) =>
         break;
       case CONSTS.SEARCH_TYPES.FIRST_LETTERS_ENGLISH:
         searchCol = 'FirstLetterEng';
-        condition = `${searchCol} CONTAINS '${saniQuery}'`;
+        condition = `${searchCol} CONTAINS[c] '${saniQuery}'`;
         if (searchSource !== 'all') {
           condition += ` AND Source.SourceID = '${searchSource}'`;
         }


### PR DESCRIPTION
Found an edge case, where one of the shabad has uppercase in its FirstLetterEng column. This implements a case insensitive search to fix that.