### PR TITLE
fix: prevent Hindi/Devanagari font overlap at large sizes

### DIFF
--- a/www/main/settings/components/SettingViewer.jsx
+++ b/www/main/settings/components/SettingViewer.jsx
@@ -90,7 +90,7 @@ const SettingViewer = () => {
       </div>
     ),
     'translation-hindi': (
-      <div className="slide-translation translation">
+      <div className="slide-translation translation hindi" lang="hi">
         <span className="hindi-translation transtext">
           हे भाई ! प्रभू के दास अपने प्रभू से जो कुछ माँगते हैं वह वही कुछ उनको देता है।
         </span>
@@ -114,12 +114,12 @@ const SettingViewer = () => {
       </div>
     ),
     'transliteration-hindi': (
-      <div className="slide-transliteration transliteration">
+      <div className="slide-transliteration transliteration devanagari" lang="hi">
         जो मागहि ठाकुर अपुने ते सोई सोई देवै ॥
       </div>
     ),
     'transliteration-shahmukhi': (
-      <div className="slide-transliteration transliteration">
+      <div className="slide-transliteration transliteration shahmukhi" lang="pa-Arab">
         {' '}
         جو ماگه ٹھاکر اپنے تے سوای سوای دےوَے ۔۔
       </div>

--- a/www/main/viewer/Slide/SlideTranslation.jsx
+++ b/www/main/viewer/Slide/SlideTranslation.jsx
@@ -35,22 +35,35 @@ const SlideTranslation = ({ getFontSize, translationObj, translationHTML, lang, 
 
   const customStyle = getFontSize(fontSizes[position]);
 
+  const scriptClass = {
+    'translation-hindi': 'hindi',
+  }[lang];
+
+  const langAttr = {
+    'translation-english': 'en',
+    'translation-spanish': 'es',
+    'translation-hindi': 'hi',
+  }[lang];
+
+  const className = ['slide-translation', scriptClass].filter(Boolean).join(' ');
+
   if (translationHTML) {
     translationMarkup = (
       <div
-        className={`slide-translation custom-english`}
+        className={`${className} custom-english`}
         style={customStyle}
+        lang={langAttr}
         dangerouslySetInnerHTML={{ __html: translationHTML }}
       />
     );
   } else if (translationString) {
     translationMarkup = (
-      <div className={`slide-translation`} style={customStyle}>
+      <div className={className} style={customStyle} lang={langAttr}>
         {translationString}
       </div>
     );
   } else {
-    translationMarkup = <div className={`slide-translation`} style={customStyle}></div>;
+    translationMarkup = <div className={className} style={customStyle} lang={langAttr}></div>;
   }
 
   return translationMarkup;

--- a/www/main/viewer/Slide/SlideTransliteration.jsx
+++ b/www/main/viewer/Slide/SlideTransliteration.jsx
@@ -33,9 +33,22 @@ const SlideTransliteration = ({ getFontSize, gurmukhiString, lang, position }) =
 
   const customStyle = getFontSize(fontSizes[position]);
 
+  const scriptClass = {
+    'transliteration-punjabi': 'shahmukhi',
+    'transliteration-hindi': 'devanagari',
+  }[lang];
+
+  const langAttr = {
+    'transliteration-english': 'en',
+    'transliteration-punjabi': 'pa-Arab',
+    'transliteration-hindi': 'hi',
+  }[lang];
+
+  const className = ['slide-transliteration', scriptClass].filter(Boolean).join(' ');
+
   return (
     transliterationString && (
-      <div className={`slide-transliteration`} style={customStyle}>
+      <div className={className} style={customStyle} lang={langAttr}>
         {transliterationString}
       </div>
     )

--- a/www/src/scss/viewer/verse-slide/_verse-slide.scss
+++ b/www/src/scss/viewer/verse-slide/_verse-slide.scss
@@ -84,6 +84,15 @@
     overflow-y: auto;
     justify-content: space-evenly;
   }
+
+  // Devanagari: avoid synthetic bold stroke thickening that overlaps conjuncts/matras at large sizes
+  &.hindi {
+    font-family: 'Noto Sans Devanagari', 'Kohinoor Devanagari', 'ITF Devanagari', 'Nirmala UI',
+      'Mangal', 'Devanagari Sangam MN', sans-serif;
+    font-synthesis: none;
+    font-weight: normal;
+    line-height: 1.5;
+  }
 }
 
 .slide-teeka {
@@ -95,6 +104,25 @@
 .slide-transliteration {
   font-weight: 600;
   margin: 10px 0;
+
+  // Devanagari: avoid synthetic bold stroke thickening that overlaps conjuncts/matras at large sizes
+  &.devanagari {
+    font-family: 'Noto Sans Devanagari', 'Kohinoor Devanagari', 'ITF Devanagari', 'Nirmala UI',
+      'Mangal', 'Devanagari Sangam MN', sans-serif;
+    font-synthesis: none;
+    font-weight: normal;
+    line-height: 1.5;
+    text-transform: none;
+  }
+
+  &.shahmukhi {
+    font-family: 'Noto Nastaliq Urdu', 'Noto Sans Arabic', 'Geeza Pro', 'Segoe UI', 'Arial',
+      sans-serif;
+    font-synthesis: none;
+    font-weight: normal;
+    line-height: 1.6;
+    text-transform: none;
+  }
 }
 
 .slide-next-line {


### PR DESCRIPTION
## Summary
Fixes Devanagari glyph overlap at large font sizes by using a proper Devanagari font stack and disabling synthetic bold.

## Changes
- Add script-specific classes for Hindi translation and Devanagari/Shahmukhi transliteration
- CSS: font-synthesis none, normal weight, better line-height
- Settings preview updated to match

## Test plan
- [ ] Enable Hindi translation → increase font size → no matra/conjunct overlap
- [ ] Enable Hindi transliteration → same check
- [ ] English translation/transliteration unchanged